### PR TITLE
Add stack for core resources

### DIFF
--- a/src/integ_test_resources/android/sdk/integration/cdk/app.py
+++ b/src/integ_test_resources/android/sdk/integration/cdk/app.py
@@ -2,13 +2,16 @@
 
 from aws_cdk import core
 
+from cdk_integration_tests_android.apigateway_stack import ApiGatewayStack
+from cdk_integration_tests_android.core_stack import CoreStack
 from cdk_integration_tests_android.pinpoint_stack import PinpointStack
 from cdk_integration_tests_android.textract_stack import TextractStack
-from cdk_integration_tests_android.apigateway_stack import ApiGatewayStack
+
 
 app = core.App()
 
 ApiGatewayStack(app, 'cdk-integration-tests-android-apigateway')
+CoreStack(app, 'cdk-integration-tests-android-core')
 PinpointStack(app, 'cdk-integration-tests-android-pinpoint')
 TextractStack(app, 'cdk-integration-tests-android-textract')
 

--- a/src/integ_test_resources/android/sdk/integration/cdk/cdk_integration_tests_android/core_stack.py
+++ b/src/integ_test_resources/android/sdk/integration/cdk/cdk_integration_tests_android/core_stack.py
@@ -1,0 +1,66 @@
+import random
+
+from aws_cdk import aws_cognito as cognito
+from aws_cdk import aws_iam as iam
+from aws_cdk import core
+
+from parameters import string_parameter
+
+
+class CoreStack(core.Stack):
+
+    def __init__(self, scope: core.Construct, id: str, **kwargs) -> None:
+        self.stack = 'core'
+
+        super().__init__(scope, id, **kwargs)
+
+        # Create the Cognito identity pool
+        identity_pool = cognito.CfnIdentityPool(
+            self, 'identityPool',
+            identity_pool_name='testIdentityPool',
+            allow_unauthenticated_identities=True
+        )
+
+        # Create the authenticated and authenticated roles
+        # TODO: The auth role will likely need additional permissions as there's
+        # some coupling to the Kinesis tests.
+        unauth_role = iam.Role(
+            self, 'unauthRole',
+            assumed_by=self.principal_for(identity_pool, 'unauthenticated')
+         )
+        auth_role = iam.Role(
+            self, 'authRole',
+            assumed_by=self.principal_for(identity_pool, 'authenticated')
+         )
+
+        # Attach the two roles
+        cognito.CfnIdentityPoolRoleAttachment(
+            self, 'identityPoolRoles',
+            identity_pool_id=identity_pool.ref,
+            roles={
+                'authenticated': auth_role.role_arn,
+                'unauthenticated': unauth_role.role_arn
+            }
+        )
+
+        # Create an SSM parameter for the identity pool ID
+        # endpoint, and the API key
+        string_parameter(self, 'identity_pool_id', identity_pool.ref)
+
+    def principal_for(
+            self,
+            identity_pool: cognito.CfnIdentityPool,
+            state: str
+    ) -> iam.FederatedPrincipal:
+        return iam.FederatedPrincipal(
+            federated='cognito-identity.amazonaws.com',
+            assume_role_action='sts:AssumeRoleWithWebIdentity',
+            conditions={
+                'StringEquals': {
+                    'cognito-identity.amazonaws.com:aud': identity_pool.ref
+                 },
+                'ForAnyValue:StringLike': {
+                    'cognito-identity.amazonaws.com:amr': state
+                }
+            }
+        )


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Creates resources required to successfully run aws-android-sdk-core which is limited to a single Cognito identity pool. Note there is some coupling between this suite and the Kinesis suite, and I've left those tests to be resolved later.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
