### PR TITLE
Use stack name instead of additional string

### DIFF
--- a/src/integ_test_resources/android/sdk/integration/cdk/app.py
+++ b/src/integ_test_resources/android/sdk/integration/cdk/app.py
@@ -10,9 +10,9 @@ from cdk_integration_tests_android.textract_stack import TextractStack
 
 app = core.App()
 
-ApiGatewayStack(app, 'cdk-integration-tests-android-apigateway')
-CoreStack(app, 'cdk-integration-tests-android-core')
-PinpointStack(app, 'cdk-integration-tests-android-pinpoint')
-TextractStack(app, 'cdk-integration-tests-android-textract')
+ApiGatewayStack(app, 'apigateway')
+CoreStack(app, 'core')
+PinpointStack(app, 'pinpoint')
+TextractStack(app, 'textract')
 
 app.synth()

--- a/src/integ_test_resources/android/sdk/integration/cdk/cdk_integration_tests_android/apigateway_stack.py
+++ b/src/integ_test_resources/android/sdk/integration/cdk/cdk_integration_tests_android/apigateway_stack.py
@@ -11,8 +11,6 @@ class ApiGatewayStack(core.Stack):
     ENDPOINT = 'https://{id}.execute-api.us-east-2.amazonaws.com/prod'
 
     def __init__(self, scope: core.Construct, id: str, **kwargs) -> None:
-        self.stack = 'apigateway'
-
         super().__init__(scope, id, **kwargs)
 
         # Create API

--- a/src/integ_test_resources/android/sdk/integration/cdk/cdk_integration_tests_android/core_stack.py
+++ b/src/integ_test_resources/android/sdk/integration/cdk/cdk_integration_tests_android/core_stack.py
@@ -10,8 +10,6 @@ from parameters import string_parameter
 class CoreStack(core.Stack):
 
     def __init__(self, scope: core.Construct, id: str, **kwargs) -> None:
-        self.stack = 'core'
-
         super().__init__(scope, id, **kwargs)
 
         # Create the Cognito identity pool

--- a/src/integ_test_resources/android/sdk/integration/cdk/cdk_integration_tests_android/parameters.py
+++ b/src/integ_test_resources/android/sdk/integration/cdk/cdk_integration_tests_android/parameters.py
@@ -7,16 +7,12 @@ NAMESPACE = ('mobile-sdk', 'android')
 
 
 def string_parameter(
-        scope: core.Construct,
+        scope: core.Stack,
         key: str,
         value: str
 ) -> ssm.StringParameter:
     """
     Saves a string parameter to the AWS Systems Manager Parameter Store.
-
-    This method saves the given value under a key. Scopes passed to this method
-    must include a `stack` attribute which is used in forming the fully
-    qualified parameter name.
 
     The fully qualified parameter name will always start with mobile-sdk and
     android, followed by the stack name, and the passed key name. For example,
@@ -25,7 +21,7 @@ def string_parameter(
 
     /mobile-sdk/android/apigateway/api_name
     """
-    tail = (scope.stack, key)
+    tail = (scope.stack_name, key)
     resource_id = '_'.join(tail)
     fqpn = '/' + '/'.join(NAMESPACE + tail)
 


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* We're already defining a stack name when we instantiate our stack, so instead of creating another attribute, reuse the existing one. This change also shortens the stack names in order to be usable for the testconfiguration.json file generation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
