### PR TITLE
Create two identity pools

### DIFF
--- a/src/integ_test_resources/android/sdk/integration/cdk/cdk_integration_tests_android/core_stack.py
+++ b/src/integ_test_resources/android/sdk/integration/cdk/cdk_integration_tests_android/core_stack.py
@@ -10,28 +10,33 @@ class CoreStack(core.Stack):
     def __init__(self, scope: core.Construct, id: str, **kwargs) -> None:
         super().__init__(scope, id, **kwargs)
 
+        identity_pools = [self.identity_pool(i) for i in range(2)]
+
+        # Create an SSM parameter for the identity pool IDs
+        string_parameter(self, 'identity_pool_id', identity_pools[0].ref)
+        string_parameter(self, 'other_identity_pool_id', identity_pools[1].ref)
+
+    def identity_pool(self, id) -> None:
         # Create the Cognito identity pool
         identity_pool = cognito.CfnIdentityPool(
-            self, 'identityPool',
+            self, f'identityPool{id}',
             identity_pool_name='testIdentityPool',
             allow_unauthenticated_identities=True
         )
 
         # Create the authenticated and authenticated roles
-        # TODO: The auth role will likely need additional permissions as there's
-        # some coupling to the Kinesis tests.
         unauth_role = iam.Role(
-            self, 'unauthRole',
+            self, f'unauthRole{id}',
             assumed_by=self.principal_for(identity_pool, 'unauthenticated')
          )
         auth_role = iam.Role(
-            self, 'authRole',
+            self, f'authRole{id}',
             assumed_by=self.principal_for(identity_pool, 'authenticated')
          )
 
         # Attach the two roles
         cognito.CfnIdentityPoolRoleAttachment(
-            self, 'identityPoolRoles',
+            self, f'identityPoolRoles{id}',
             identity_pool_id=identity_pool.ref,
             roles={
                 'authenticated': auth_role.role_arn,
@@ -39,9 +44,7 @@ class CoreStack(core.Stack):
             }
         )
 
-        # Create an SSM parameter for the identity pool ID
-        # endpoint, and the API key
-        string_parameter(self, 'identity_pool_id', identity_pool.ref)
+        return identity_pool
 
     def principal_for(
             self,


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Previously core looked into the kinesis namespace for an additional identity pool for testing. This change creates two identity pools within core for use in this testing. See https://github.com/aws-amplify/aws-sdk-android/pull/1638 for the corresponding change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.