### PR TITLE
Fix output names and remove pretend endpoint

### DIFF
--- a/src/integ_test_resources/android/sdk/integration/cdk/cdk_integration_tests_android/apigateway_stack.py
+++ b/src/integ_test_resources/android/sdk/integration/cdk/cdk_integration_tests_android/apigateway_stack.py
@@ -60,12 +60,10 @@ class ApiGatewayStack(core.Stack):
             integration = apigateway.HttpIntegration(url, http_method=method)
             echo.add_method(method.upper(), integration)
 
-        # Create SSM parameters for the endpoint of the API, a pretend
-        # endpoint, and the API key
+        # Create SSM parameters for the endpoint of the API and the API key
         pretend_endpoint = self.ENDPOINT.format(id=self.random_hex(10))
 
-        string_parameter(self, 'endpoint_us_east_1', api.url)
-        string_parameter(self, 'endpoint_us_east_2', pretend_endpoint)
+        string_parameter(self, 'endpoint', api.url)
         string_parameter(self, 'api_key', api_key_value)
 
     def random_hex(self, length):


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* The tests don't actually need a pretend endpoint, and are better rewritten to just use a really pretend region versus an actual API Gateway endpoint in another region. This change eliminates the pretend endpoint and takes the region name out of the endpoint string.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.