### PR TITLE
Eliminate identity checks

### DIFF
--- a/src/integ_test_resources/common/device_config_builder.py
+++ b/src/integ_test_resources/common/device_config_builder.py
@@ -60,7 +60,7 @@ class DeviceConfigBuilder:
         """
         key = key.strip('/')
         first_slash_pos = key.find('/')
-        if first_slash_pos is -1:
+        if first_slash_pos == -1:
             # If the key didn't have a '/', its just a simple leaf, and
             # we can store the value, here.
             all_package_data[key] = value
@@ -149,7 +149,7 @@ class DeviceConfigBuilder:
         }, indent=2))
 
 if __name__ == "__main__":
-    if len(sys.argv) is not 2:
+    if len(sys.argv) != 2:
         raise Exception('Usage: ' + sys.argv[0] + ' <ios|android>')
     config_builder = DeviceConfigBuilder(sys.argv[1])
     config_builder.print_device_config()


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Identity checks are not guaranteed to work against numbers and strings in the language spec, and although these work now in CPython, they aren't guaranteed to work in the future. Python 3.8 will throw a SyntaxWarning for these lines. See https://docs.python.org/3.8/whatsnew/3.8.html#changes-in-python-behavior for more details.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.