### PR TITLE
snakeCase keys in root of testconfiguration.json

### DIFF
--- a/src/integ_test_resources/common/device_config_builder.py
+++ b/src/integ_test_resources/common/device_config_builder.py
@@ -140,12 +140,12 @@ class DeviceConfigBuilder:
         parameters = self.get_parameters_with_prefix(parameter_prefix, ssm)
         package_data = self.build_package_data(parameter_prefix, parameters)
         print(json.dumps({
-            'Credentials': {
+            'credentials': {
                 'accessKey': aws_config.accessKey,
                 'secretKey': aws_config.secretKey,
                 'sessionToken': aws_config.sessionToken
             },
-            'Packages': package_data
+            'packages': package_data
         }, indent=2))
 
 if __name__ == "__main__":


### PR DESCRIPTION
In the generated `testconfiguration.json`, `"Packages"` and `"Credentials"`
should use snakeCase identifiers, instead: `"packages"`, and
`"credentials"`.

While there is no format convention on the naming and casing of JSON
keys, some popular corporate style guides _do_ guide developers to use
snakeCased ASCII identifiers.

Refer: https://stackoverflow.com/a/19287394/695787

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
