### PR TITLE
add region to be saved from common_stack to parameter store

### DIFF
--- a/src/integ_test_resources/common/common_stack.py
+++ b/src/integ_test_resources/common/common_stack.py
@@ -1,3 +1,4 @@
+import os
 from aws_cdk import aws_cognito, aws_iam, core
 
 from common.auth_utils import construct_identity_pool
@@ -67,6 +68,7 @@ class CommonStack(RegionAwareStack):
         self.parameters_to_save["identityPoolId"] = cognito_identity_pool.ref
         self.parameters_to_save["authRoleArn"] = cognito_identity_pool_auth_role.role_arn
         self.parameters_to_save["unauthRoleArn"] = cognito_identity_pool_auth_role.role_arn
+        self.parameters_to_save["region"] = os.environ["AWS_DEFAULT_REGION"]
 
     @property
     def circleci_execution_role(self) -> aws_iam.Role:


### PR DESCRIPTION
*Issue #, if available:*
Provision integration test resources through CDK

*Description of changes:*
This change makes sure region is saved in parameter store from common_stack.
It is fetched from `AWS_DEFAULT_REGION` env variable on which the builder_test_config script also depends.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
