### PR TITLE
Added more iOS stacks

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ aws_cdk.aws_apigateway
 aws_cdk.aws_cognito
 aws_cdk.aws_iam
 aws_cdk.aws_iot
+aws_cdk.aws_kinesis
 aws_cdk.aws_kinesisfirehose
 aws_cdk.aws_kms
 aws_cdk.aws_logs

--- a/src/integ_test_resources/common/region_aware_stack.py
+++ b/src/integ_test_resources/common/region_aware_stack.py
@@ -31,7 +31,7 @@ class RegionAwareStack(core.Stack):
 
     def are_services_supported_in_region(
         self, service_names: list, region_name: str = None
-    ) -> None:
+    ) -> bool:
 
         services_supported_in_region = True
         for service_name in service_names:

--- a/src/integ_test_resources/common/region_aware_stack.py
+++ b/src/integ_test_resources/common/region_aware_stack.py
@@ -12,7 +12,7 @@ class RegionAwareStack(core.Stack):
         super().__init__(scope, id, **kwargs)
 
         self._supported_in_region: bool
-        self._parameters_to_save: dict
+        self._parameters_to_save = {}
 
     def is_service_supported_in_region(
         self, service_name: str = None, region_name: str = None

--- a/src/integ_test_resources/common/scripts/device_config_builder.py
+++ b/src/integ_test_resources/common/scripts/device_config_builder.py
@@ -11,7 +11,7 @@ import boto3
 sys.path.append(str(pathlib.Path(__file__).parent.absolute()) + "/..")
 from platforms import Platform
 
-SUPPORTED_PLATFORMS = list(map(lambda p: p.value, Platform))
+SUPPORTED_PLATFORMS = [platform.value for platform in Platform]
 
 
 class DeviceConfigBuilder:

--- a/src/integ_test_resources/ios/sdk/integration/cdk/app.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/app.py
@@ -11,6 +11,7 @@ from cdk_integration_tests_ios.core_stack import CoreStack
 from cdk_integration_tests_ios.dynamodb_stack import DynamoDbStack
 from cdk_integration_tests_ios.ec2_stack import Ec2Stack
 from cdk_integration_tests_ios.elb_stack import ElbStack
+from cdk_integration_tests_ios.firehose_stack import FirehoseStack
 from cdk_integration_tests_ios.iot_stack import IotStack
 from cdk_integration_tests_ios.kms_stack import KmsStack
 from cdk_integration_tests_ios.lambda_stack import LambdaStack
@@ -44,6 +45,7 @@ comprehend_stack = ComprehendStack(app, "comprehend", common_stack)
 dynamodb_stack = DynamoDbStack(app, "dynamodb", common_stack)
 ec2_stack = Ec2Stack(app, "ec2", common_stack)
 elb_stack = ElbStack(app, "elb", common_stack)
+firehose_stack = FirehoseStack(app, "firehose", common_stack)
 iot_stack = IotStack(app, "iot", common_stack)
 kms_stack = KmsStack(app, "kms", common_stack)
 mobileclient_stack = MobileClientStack(app, "mobileclient", common_stack)

--- a/src/integ_test_resources/ios/sdk/integration/cdk/app.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/app.py
@@ -14,6 +14,7 @@ from cdk_integration_tests_ios.elb_stack import ElbStack
 from cdk_integration_tests_ios.firehose_stack import FirehoseStack
 from cdk_integration_tests_ios.iot_stack import IotStack
 from cdk_integration_tests_ios.kms_stack import KmsStack
+from cdk_integration_tests_ios.kinesis_stack import KinesisStack
 from cdk_integration_tests_ios.lambda_stack import LambdaStack
 from cdk_integration_tests_ios.mobileclient_stack import MobileClientStack
 from cdk_integration_tests_ios.pinpoint_stack import PinpointStack
@@ -47,6 +48,7 @@ ec2_stack = Ec2Stack(app, "ec2", common_stack)
 elb_stack = ElbStack(app, "elb", common_stack)
 firehose_stack = FirehoseStack(app, "firehose", common_stack)
 iot_stack = IotStack(app, "iot", common_stack)
+kinesis_stack = KinesisStack(app, "kinesis", common_stack)
 kms_stack = KmsStack(app, "kms", common_stack)
 mobileclient_stack = MobileClientStack(app, "mobileclient", common_stack)
 pinpoint_stack = PinpointStack(app, "pinpoint", common_stack)
@@ -63,6 +65,7 @@ stacks_in_app = [
     dynamodb_stack,
     ec2_stack,
     iot_stack,
+    kinesis_stack,
     kms_stack,
     lambda_stack,
     mobileclient_stack,

--- a/src/integ_test_resources/ios/sdk/integration/cdk/app.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/app.py
@@ -19,6 +19,7 @@ from cdk_integration_tests_ios.kms_stack import KmsStack
 from cdk_integration_tests_ios.lambda_stack import LambdaStack
 from cdk_integration_tests_ios.mobileclient_stack import MobileClientStack
 from cdk_integration_tests_ios.pinpoint_stack import PinpointStack
+from cdk_integration_tests_ios.polly_stack import PollyStack
 from cdk_integration_tests_ios.sns_stack import SnsStack
 from cdk_integration_tests_ios.sts_stack import StsStack
 from common.common_stack import CommonStack
@@ -54,6 +55,7 @@ kinesisvideo_stack = KinesisVideoStack(app, "kinesisvideo", common_stack)
 kms_stack = KmsStack(app, "kms", common_stack)
 mobileclient_stack = MobileClientStack(app, "mobileclient", common_stack)
 pinpoint_stack = PinpointStack(app, "pinpoint", common_stack)
+polly_stack = PollyStack(app, "polly", common_stack)
 sns_stack = SnsStack(app, "sns", common_stack)
 sts_stack = StsStack(app, "sts", common_stack)
 
@@ -73,6 +75,7 @@ stacks_in_app = [
     lambda_stack,
     mobileclient_stack,
     pinpoint_stack,
+    polly_stack,
     sns_stack,
     sts_stack,
 ]

--- a/src/integ_test_resources/ios/sdk/integration/cdk/app.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/app.py
@@ -12,6 +12,7 @@ from cdk_integration_tests_ios.dynamodb_stack import DynamoDbStack
 from cdk_integration_tests_ios.ec2_stack import Ec2Stack
 from cdk_integration_tests_ios.elb_stack import ElbStack
 from cdk_integration_tests_ios.iot_stack import IotStack
+from cdk_integration_tests_ios.kms_stack import KmsStack
 from cdk_integration_tests_ios.lambda_stack import LambdaStack
 from cdk_integration_tests_ios.mobileclient_stack import MobileClientStack
 from cdk_integration_tests_ios.pinpoint_stack import PinpointStack
@@ -43,7 +44,8 @@ comprehend_stack = ComprehendStack(app, "comprehend", common_stack)
 dynamodb_stack = DynamoDbStack(app, "dynamodb", common_stack)
 ec2_stack = Ec2Stack(app, "ec2", common_stack)
 elb_stack = ElbStack(app, "elb", common_stack)
-iot_core_stack = IotStack(app, "iot", common_stack)
+iot_stack = IotStack(app, "iot", common_stack)
+kms_stack = KmsStack(app, "kms", common_stack)
 mobileclient_stack = MobileClientStack(app, "mobileclient", common_stack)
 pinpoint_stack = PinpointStack(app, "pinpoint", common_stack)
 sns_stack = SnsStack(app, "sns", common_stack)
@@ -58,7 +60,8 @@ stacks_in_app = [
     comprehend_stack,
     dynamodb_stack,
     ec2_stack,
-    iot_core_stack,
+    iot_stack,
+    kms_stack,
     lambda_stack,
     mobileclient_stack,
     pinpoint_stack,

--- a/src/integ_test_resources/ios/sdk/integration/cdk/app.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/app.py
@@ -21,6 +21,7 @@ from cdk_integration_tests_ios.mobileclient_stack import MobileClientStack
 from cdk_integration_tests_ios.pinpoint_stack import PinpointStack
 from cdk_integration_tests_ios.polly_stack import PollyStack
 from cdk_integration_tests_ios.rekognition_stack import RekognitionStack
+from cdk_integration_tests_ios.s3_stack import S3Stack
 from cdk_integration_tests_ios.sns_stack import SnsStack
 from cdk_integration_tests_ios.sts_stack import StsStack
 from common.common_stack import CommonStack
@@ -58,6 +59,7 @@ mobileclient_stack = MobileClientStack(app, "mobileclient", common_stack)
 pinpoint_stack = PinpointStack(app, "pinpoint", common_stack)
 polly_stack = PollyStack(app, "polly", common_stack)
 rekognition_stack = RekognitionStack(app, "rekognition", common_stack)
+s3_stack = S3Stack(app, "s3", common_stack)
 sns_stack = SnsStack(app, "sns", common_stack)
 sts_stack = StsStack(app, "sts", common_stack)
 
@@ -78,6 +80,8 @@ stacks_in_app = [
     mobileclient_stack,
     pinpoint_stack,
     polly_stack,
+    rekognition_stack,
+    s3_stack,
     sns_stack,
     sts_stack,
 ]

--- a/src/integ_test_resources/ios/sdk/integration/cdk/app.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/app.py
@@ -20,6 +20,7 @@ from cdk_integration_tests_ios.lambda_stack import LambdaStack
 from cdk_integration_tests_ios.mobileclient_stack import MobileClientStack
 from cdk_integration_tests_ios.pinpoint_stack import PinpointStack
 from cdk_integration_tests_ios.polly_stack import PollyStack
+from cdk_integration_tests_ios.rekognition_stack import RekognitionStack
 from cdk_integration_tests_ios.sns_stack import SnsStack
 from cdk_integration_tests_ios.sts_stack import StsStack
 from common.common_stack import CommonStack
@@ -56,6 +57,7 @@ kms_stack = KmsStack(app, "kms", common_stack)
 mobileclient_stack = MobileClientStack(app, "mobileclient", common_stack)
 pinpoint_stack = PinpointStack(app, "pinpoint", common_stack)
 polly_stack = PollyStack(app, "polly", common_stack)
+rekognition_stack = RekognitionStack(app, "rekognition", common_stack)
 sns_stack = SnsStack(app, "sns", common_stack)
 sts_stack = StsStack(app, "sts", common_stack)
 

--- a/src/integ_test_resources/ios/sdk/integration/cdk/app.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/app.py
@@ -13,9 +13,9 @@ from cdk_integration_tests_ios.ec2_stack import Ec2Stack
 from cdk_integration_tests_ios.elb_stack import ElbStack
 from cdk_integration_tests_ios.firehose_stack import FirehoseStack
 from cdk_integration_tests_ios.iot_stack import IotStack
-from cdk_integration_tests_ios.kms_stack import KmsStack
 from cdk_integration_tests_ios.kinesis_stack import KinesisStack
 from cdk_integration_tests_ios.kinesisvideo_stack import KinesisVideoStack
+from cdk_integration_tests_ios.kms_stack import KmsStack
 from cdk_integration_tests_ios.lambda_stack import LambdaStack
 from cdk_integration_tests_ios.mobileclient_stack import MobileClientStack
 from cdk_integration_tests_ios.pinpoint_stack import PinpointStack

--- a/src/integ_test_resources/ios/sdk/integration/cdk/app.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/app.py
@@ -15,6 +15,7 @@ from cdk_integration_tests_ios.firehose_stack import FirehoseStack
 from cdk_integration_tests_ios.iot_stack import IotStack
 from cdk_integration_tests_ios.kms_stack import KmsStack
 from cdk_integration_tests_ios.kinesis_stack import KinesisStack
+from cdk_integration_tests_ios.kinesisvideo_stack import KinesisVideoStack
 from cdk_integration_tests_ios.lambda_stack import LambdaStack
 from cdk_integration_tests_ios.mobileclient_stack import MobileClientStack
 from cdk_integration_tests_ios.pinpoint_stack import PinpointStack
@@ -49,6 +50,7 @@ elb_stack = ElbStack(app, "elb", common_stack)
 firehose_stack = FirehoseStack(app, "firehose", common_stack)
 iot_stack = IotStack(app, "iot", common_stack)
 kinesis_stack = KinesisStack(app, "kinesis", common_stack)
+kinesisvideo_stack = KinesisVideoStack(app, "kinesisvideo", common_stack)
 kms_stack = KmsStack(app, "kms", common_stack)
 mobileclient_stack = MobileClientStack(app, "mobileclient", common_stack)
 pinpoint_stack = PinpointStack(app, "pinpoint", common_stack)
@@ -66,6 +68,7 @@ stacks_in_app = [
     ec2_stack,
     iot_stack,
     kinesis_stack,
+    kinesisvideo_stack,
     kms_stack,
     lambda_stack,
     mobileclient_stack,

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/core_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/core_stack.py
@@ -16,7 +16,7 @@ class CoreStack(RegionAwareStack):
 
         self._supported_in_region = self.are_services_supported_in_region(["cognito-identity"])
 
-        (self._facebook_app_id, self._facebook_app_secret) = self.get_facebook_app_config()
+        (self._facebook_app_id, self._facebook_app_secret) = CoreStack.get_facebook_app_config()
 
         supported_login_providers = {"graph.facebook.com": self._facebook_app_id}
         (
@@ -56,12 +56,12 @@ class CoreStack(RegionAwareStack):
 
         self.save_parameters_in_parameter_store(platform=Platform.IOS)
 
-    def get_facebook_app_config(self) -> tuple:
-
+    @staticmethod
+    def get_facebook_app_config() -> (str, str):
         ios_integ_tests_secrets = json.loads(get_integ_tests_secrets(platform=Platform.IOS))
         facebook_app_id = ios_integ_tests_secrets["IOS_FB_AWSCORETESTS_APP_ID"]
         facebook_app_secret = ios_integ_tests_secrets["IOS_FB_AWSCORETESTS_APP_SECRET"]
-        return (facebook_app_id, facebook_app_secret)
+        return facebook_app_id, facebook_app_secret
 
     def construct_identity_pool_with_facebook_as_idp(
         self,

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/firehose_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/firehose_stack.py
@@ -1,0 +1,58 @@
+from aws_cdk import aws_iam, aws_kinesisfirehose, aws_s3, core
+
+from common.common_stack import CommonStack
+from common.platforms import Platform
+from common.region_aware_stack import RegionAwareStack
+
+
+class FirehoseStack(RegionAwareStack):
+    def __init__(self, scope: core.Construct, id: str, common_stack: CommonStack, **kwargs) -> None:
+        super().__init__(scope, id, **kwargs)
+
+        self._supported_in_region = self.is_service_supported_in_region()
+
+        delivery_bucket = aws_s3.Bucket(
+            self,
+            "integ-test-firehose-delivery-bucket"
+        )
+        delivery_role = aws_iam.Role(
+            self,
+            "integ-test-firehose-delivery-role",
+            assumed_by=aws_iam.ServicePrincipal("firehose.amazonaws.com")
+        )
+        wic_provider_test_role.add_to_policy(
+            aws_iam.PolicyStatement(
+                effect=aws_iam.Effect.ALLOW, actions=["translate:TranslateText"], resources=["*"]
+            )
+        )
+
+        firehose = aws_kinesisfirehose.CfnDeliveryStream(
+            self,
+            "integ-test-firehose",
+            s3_destination_configuration={
+                "bucketArn": delivery_bucket.bucket_arn,
+                "bufferingHints": {
+                     "intervalInSeconds": 60,
+                     "sizeInMBs": 50
+                },
+                "compressionFormat": "ZIP"
+            }
+        )
+        firehose_arn = firehose.get_att("Arn").to_string()
+
+        all_resources_policy = aws_iam.PolicyStatement(
+            effect=aws_iam.Effect.ALLOW,
+            actions=["firehose:DescribeLoadBalancers"],
+            resources=["*"],
+        )
+        common_stack.add_to_common_role_policies(self, policy_to_add=all_resources_policy)
+
+        deliverystream_policy = aws_iam.PolicyStatement(
+            effect=aws_iam.Effect.ALLOW,
+            actions=["firehose:PutRecordBatch"],
+            resources=[firehose_arn],
+        )
+        common_stack.add_to_common_role_policies(self, policy_to_add=deliverystream_policy)
+
+        self._parameters_to_save["firehose_arn"] = firehose_arn
+        self.save_parameters_in_parameter_store(Platform.IOS)

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/firehose_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/firehose_stack.py
@@ -1,4 +1,4 @@
-from aws_cdk import aws_iam, aws_kinesisfirehose, aws_s3, core
+from aws_cdk import aws_iam, aws_kinesisfirehose, aws_logs, aws_s3, core
 
 from common.common_stack import CommonStack
 from common.platforms import Platform
@@ -6,53 +6,147 @@ from common.region_aware_stack import RegionAwareStack
 
 
 class FirehoseStack(RegionAwareStack):
+    # Hardcoded because LogGroup and LogStream don't support the .ref property
+    LOG_GROUP_NAME = "integ_test_firehose_log_group"
+    LOG_STREAM_NAME = "integ_test_firehose_log_stream"
+
     def __init__(self, scope: core.Construct, id: str, common_stack: CommonStack, **kwargs) -> None:
         super().__init__(scope, id, **kwargs)
 
         self._supported_in_region = self.is_service_supported_in_region()
 
-        delivery_bucket = aws_s3.Bucket(
+        delivery_bucket = self.create_s3_delivery_bucket()
+        log_group = self.create_log_group_and_stream()
+        firehose_role_arn = self.create_firehose_role(delivery_bucket, log_group)
+
+        firehose = self.create_firehose(delivery_bucket, firehose_role_arn)
+        firehose_stream_name = firehose.ref
+        self._parameters_to_save["firehose_stream_name"] = firehose_stream_name
+
+        firehose_arn = firehose.get_att("Arn").to_string()
+        self.create_test_policies(firehose_arn, common_stack)
+
+        self.save_parameters_in_parameter_store(Platform.IOS)
+
+    def create_s3_delivery_bucket(self) -> aws_s3.Bucket:
+        delivery_bucket = aws_s3.Bucket(self, "integ_test_firehose_delivery_bucket")
+        return delivery_bucket
+
+    def create_log_group_and_stream(self) -> aws_logs.LogGroup:
+        log_group = aws_logs.LogGroup(
             self,
-            "integ-test-firehose-delivery-bucket"
+            "integ_test_firehose_delivery_log_group",
+            log_group_name=FirehoseStack.LOG_GROUP_NAME,
         )
-        delivery_role = aws_iam.Role(
+        aws_logs.LogStream(
             self,
-            "integ-test-firehose-delivery-role",
-            assumed_by=aws_iam.ServicePrincipal("firehose.amazonaws.com")
+            "integ_test_firehose_delivery_log_stream",
+            log_group=log_group,
+            log_stream_name=FirehoseStack.LOG_STREAM_NAME,
         )
-        wic_provider_test_role.add_to_policy(
+        return log_group
+
+    def create_firehose_role(self, delivery_bucket, log_group) -> str:
+        """
+        Creates an IAM role to allow Kinesis to deliver records to S3, per
+        https://docs.aws.amazon.com/firehose/latest/dev/controlling-access.html
+
+        :param delivery_bucket: The destination bucket
+        :param log_group: The CloudWatch log group that owns log_stream
+        :return: IAM Role ARN
+        """
+        firehose_role = aws_iam.Role(
+            self,
+            "integ_test_firehose_delivery_role",
+            assumed_by=aws_iam.ServicePrincipal("firehose.amazonaws.com"),
+        )
+
+        firehose_role.add_to_policy(
             aws_iam.PolicyStatement(
-                effect=aws_iam.Effect.ALLOW, actions=["translate:TranslateText"], resources=["*"]
+                effect=aws_iam.Effect.ALLOW,
+                actions=[
+                    "s3:AbortMultipartUpload",
+                    "s3:GetBucketLocation",
+                    "s3:GetObject",
+                    "s3:ListBucket",
+                    "s3:ListBucketMultipartUploads",
+                    "s3:PutObject",
+                ],
+                resources=[delivery_bucket.bucket_arn, f"{delivery_bucket.bucket_arn}/*"],
             )
         )
 
+        firehose_role.add_to_policy(
+            aws_iam.PolicyStatement(
+                effect=aws_iam.Effect.ALLOW,
+                actions=[
+                    "kinesis:DescribeStream",
+                    "kinesis:GetShardIterator",
+                    "kinesis:GetRecords",
+                    "kinesis:ListShards",
+                ],
+                resources=[f"arn:aws:kinesis:{self.region}:{self.account}:stream/*"],
+            )
+        )
+
+        log_stream_arn = ":".join(
+            [
+                "arn:aws:logs",
+                self.region,
+                self.account,
+                "log-group",
+                FirehoseStack.LOG_GROUP_NAME,
+                "log-stream",
+                FirehoseStack.LOG_STREAM_NAME,
+            ]
+        )
+        firehose_role.add_to_policy(
+            aws_iam.PolicyStatement(
+                effect=aws_iam.Effect.ALLOW,
+                actions=["logs:PutLogEvents"],
+                resources=[log_stream_arn],
+            )
+        )
+        return firehose_role.role_arn
+
+    def create_firehose(
+        self, delivery_bucket, firehose_role_arn
+    ) -> aws_kinesisfirehose.CfnDeliveryStream:
+        """
+        Creates a Firehose DeliveryStream configured to deliver to the S3 Bucket `delivery_bucket`,
+        and log errors to a log stream named 'S3Delivery' in `log_group`. Firehose will adopt the
+        role specified in `firehose_role_arn`.
+
+        :param delivery_bucket: The delivery destination bucket for the Firehose
+        :param firehose_role_arn: The role to adopt
+        :return: a CfnDeliveryStream
+        """
         firehose = aws_kinesisfirehose.CfnDeliveryStream(
             self,
-            "integ-test-firehose",
-            s3_destination_configuration={
+            "integ_test_firehose",
+            extended_s3_destination_configuration={
                 "bucketArn": delivery_bucket.bucket_arn,
-                "bufferingHints": {
-                     "intervalInSeconds": 60,
-                     "sizeInMBs": 50
+                "bufferingHints": {"intervalInSeconds": 60, "sizeInMBs": 50},
+                "compressionFormat": "ZIP",
+                "roleArn": firehose_role_arn,
+                "cloudWatchLoggingOptions": {
+                    "enabled": True,
+                    "logGroupName": FirehoseStack.LOG_GROUP_NAME,
+                    "logStreamName": FirehoseStack.LOG_STREAM_NAME,
                 },
-                "compressionFormat": "ZIP"
-            }
+            },
         )
-        firehose_arn = firehose.get_att("Arn").to_string()
+        return firehose
 
+    def create_test_policies(self, firehose_arn, common_stack):
         all_resources_policy = aws_iam.PolicyStatement(
-            effect=aws_iam.Effect.ALLOW,
-            actions=["firehose:DescribeLoadBalancers"],
-            resources=["*"],
+            effect=aws_iam.Effect.ALLOW, actions=["firehose:ListDeliveryStreams"], resources=["*"],
         )
         common_stack.add_to_common_role_policies(self, policy_to_add=all_resources_policy)
 
         deliverystream_policy = aws_iam.PolicyStatement(
             effect=aws_iam.Effect.ALLOW,
-            actions=["firehose:PutRecordBatch"],
+            actions=["firehose:PutRecord", "firehose:PutRecordBatch"],
             resources=[firehose_arn],
         )
         common_stack.add_to_common_role_policies(self, policy_to_add=deliverystream_policy)
-
-        self._parameters_to_save["firehose_arn"] = firehose_arn
-        self.save_parameters_in_parameter_store(Platform.IOS)

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/firehose_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/firehose_stack.py
@@ -6,7 +6,6 @@ from common.region_aware_stack import RegionAwareStack
 
 
 class FirehoseStack(RegionAwareStack):
-    # Hardcoded because LogGroup and LogStream don't support the .ref property
     LOG_GROUP_NAME = "integ_test_firehose_log_group"
     LOG_STREAM_NAME = "integ_test_firehose_log_stream"
 
@@ -16,8 +15,8 @@ class FirehoseStack(RegionAwareStack):
         self._supported_in_region = self.is_service_supported_in_region()
 
         delivery_bucket = self.create_s3_delivery_bucket()
-        log_group = self.create_log_group_and_stream()
-        firehose_role_arn = self.create_firehose_role(delivery_bucket, log_group)
+        self.create_log_group_and_stream()
+        firehose_role_arn = self.create_firehose_role(delivery_bucket)
 
         firehose = self.create_firehose(delivery_bucket, firehose_role_arn)
         firehose_stream_name = firehose.ref
@@ -46,13 +45,12 @@ class FirehoseStack(RegionAwareStack):
         )
         return log_group
 
-    def create_firehose_role(self, delivery_bucket, log_group) -> str:
+    def create_firehose_role(self, delivery_bucket) -> str:
         """
         Creates an IAM role to allow Kinesis to deliver records to S3, per
         https://docs.aws.amazon.com/firehose/latest/dev/controlling-access.html
 
         :param delivery_bucket: The destination bucket
-        :param log_group: The CloudWatch log group that owns log_stream
         :return: IAM Role ARN
         """
         firehose_role = aws_iam.Role(

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/kinesis_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/kinesis_stack.py
@@ -1,0 +1,39 @@
+from aws_cdk import aws_iam, core
+
+from common.common_stack import CommonStack
+from common.platforms import Platform
+from common.region_aware_stack import RegionAwareStack
+
+
+class KinesisStack(RegionAwareStack):
+
+    def __init__(self, scope: core.Construct, id: str, common_stack: CommonStack, **kwargs) -> None:
+        super().__init__(scope, id, **kwargs)
+
+        self._supported_in_region = self.is_service_supported_in_region()
+
+        all_resources_policy = aws_iam.PolicyStatement(
+            effect=aws_iam.Effect.ALLOW,
+            actions=[
+                "kinesis:ListStreams"
+            ],
+            resources=["*"],
+        )
+        common_stack.add_to_common_role_policies(self, policy_to_add=all_resources_policy)
+
+        stream_policy = aws_iam.PolicyStatement(
+            effect=aws_iam.Effect.ALLOW,
+            actions=[
+                "kinesis:CreateStream",
+                "kinesis:DeleteStream",
+                "kinesis:DescribeStream",
+                "kinesis:GetShardIterator",
+                "kinesis:GetRecords",
+                "kinesis:PutRecord",
+                "kinesis:PutRecords",
+            ],
+            resources=[f"arn:aws:kinesis:{self.region}:{self.account}:stream/*"],
+        )
+        common_stack.add_to_common_role_policies(self, policy_to_add=stream_policy)
+
+        self.save_parameters_in_parameter_store(Platform.IOS)

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/kinesis_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/kinesis_stack.py
@@ -6,18 +6,13 @@ from common.region_aware_stack import RegionAwareStack
 
 
 class KinesisStack(RegionAwareStack):
-
     def __init__(self, scope: core.Construct, id: str, common_stack: CommonStack, **kwargs) -> None:
         super().__init__(scope, id, **kwargs)
 
         self._supported_in_region = self.is_service_supported_in_region()
 
         all_resources_policy = aws_iam.PolicyStatement(
-            effect=aws_iam.Effect.ALLOW,
-            actions=[
-                "kinesis:ListStreams"
-            ],
-            resources=["*"],
+            effect=aws_iam.Effect.ALLOW, actions=["kinesis:ListStreams"], resources=["*"],
         )
         common_stack.add_to_common_role_policies(self, policy_to_add=all_resources_policy)
 

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/kinesisvideo_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/kinesisvideo_stack.py
@@ -27,6 +27,7 @@ class KinesisVideoStack(RegionAwareStack):
                 "kinesisvideo:CreateStream",
                 "kinesisvideo:DeleteStream",
                 "kinesisvideo:GetDataEndpoint",
+                "kinesisvideo:GetHLSStreamingSessionURL",
             ],
             resources=[f"arn:aws:kinesisvideo:{self.region}:{self.account}:stream/*"],
         )

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/kinesisvideo_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/kinesisvideo_stack.py
@@ -6,18 +6,13 @@ from common.region_aware_stack import RegionAwareStack
 
 
 class KinesisVideoStack(RegionAwareStack):
-
     def __init__(self, scope: core.Construct, id: str, common_stack: CommonStack, **kwargs) -> None:
         super().__init__(scope, id, **kwargs)
 
         self._supported_in_region = self.is_service_supported_in_region()
 
         all_resources_policy = aws_iam.PolicyStatement(
-            effect=aws_iam.Effect.ALLOW,
-            actions=[
-                "kinesisvideo:ListStreams"
-            ],
-            resources=["*"],
+            effect=aws_iam.Effect.ALLOW, actions=["kinesisvideo:ListStreams"], resources=["*"],
         )
         common_stack.add_to_common_role_policies(self, policy_to_add=all_resources_policy)
 

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/kinesisvideo_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/kinesisvideo_stack.py
@@ -1,0 +1,35 @@
+from aws_cdk import aws_iam, core
+
+from common.common_stack import CommonStack
+from common.platforms import Platform
+from common.region_aware_stack import RegionAwareStack
+
+
+class KinesisVideoStack(RegionAwareStack):
+
+    def __init__(self, scope: core.Construct, id: str, common_stack: CommonStack, **kwargs) -> None:
+        super().__init__(scope, id, **kwargs)
+
+        self._supported_in_region = self.is_service_supported_in_region()
+
+        all_resources_policy = aws_iam.PolicyStatement(
+            effect=aws_iam.Effect.ALLOW,
+            actions=[
+                "kinesisvideo:ListStreams"
+            ],
+            resources=["*"],
+        )
+        common_stack.add_to_common_role_policies(self, policy_to_add=all_resources_policy)
+
+        stream_policy = aws_iam.PolicyStatement(
+            effect=aws_iam.Effect.ALLOW,
+            actions=[
+                "kinesisvideo:CreateStream",
+                "kinesisvideo:DeleteStream",
+                "kinesisvideo:GetDataEndpoint",
+            ],
+            resources=[f"arn:aws:kinesisvideo:{self.region}:{self.account}:stream/*"],
+        )
+        common_stack.add_to_common_role_policies(self, policy_to_add=stream_policy)
+
+        self.save_parameters_in_parameter_store(Platform.IOS)

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/kms_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/kms_stack.py
@@ -1,0 +1,38 @@
+from aws_cdk import aws_iam, core
+
+from common.common_stack import CommonStack
+from common.region_aware_stack import RegionAwareStack
+
+
+class KmsStack(RegionAwareStack):
+    def __init__(self, scope: core.Construct, id: str, common_stack: CommonStack, **kwargs) -> None:
+        super().__init__(scope, id, **kwargs)
+
+        self._supported_in_region = self.is_service_supported_in_region()
+
+        all_resources_policy = aws_iam.PolicyStatement(
+            effect=aws_iam.Effect.ALLOW, actions=["kms:CreateKey"], resources=["*"],
+        )
+        common_stack.add_to_common_role_policies(self, policy_to_add=all_resources_policy)
+
+        alias_policy = aws_iam.PolicyStatement(
+            effect=aws_iam.Effect.ALLOW,
+            actions=["kms:CreateAlias"],
+            resources=[f"arn:aws:kms:{self.region}:{self.account}:alias*"],
+        )
+        common_stack.add_to_common_role_policies(self, policy_to_add=alias_policy)
+
+        key_policy = aws_iam.PolicyStatement(
+            effect=aws_iam.Effect.ALLOW,
+            actions=[
+                "kms:CancelKeyDeletion",
+                "kms:CreateAlias",
+                "kms:Decrypt",
+                "kms:DescribeKey",
+                "kms:DisableKeyRotation",
+                "kms:Encrypt",
+                "kms:ScheduleKeyDeletion",
+            ],
+            resources=[f"arn:aws:kms:{self.region}:{self.account}:key*"],
+        )
+        common_stack.add_to_common_role_policies(self, policy_to_add=key_policy)

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/lambda_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/lambda_stack.py
@@ -27,7 +27,7 @@ class LambdaStack(RegionAwareStack):
             ),
         )
 
-        self.attach_alias_to_version(echo.current_version, "Version2Alias")
+        version_alias_associated_version, version_alias_name = self.attach_alias_to_version(echo.current_version)
 
         echo2 = aws_lambda.Function(
             self,
@@ -40,6 +40,8 @@ class LambdaStack(RegionAwareStack):
         self._parameters_to_save = {
             "echo_function_name": echo.function_name,
             "echo2_function_name": echo2.function_name,
+            "version_alias_name": version_alias_name,
+            "version_alias_associated_version": version_alias_associated_version,
         }
         self.save_parameters_in_parameter_store(platform=Platform.IOS)
 
@@ -55,11 +57,21 @@ class LambdaStack(RegionAwareStack):
     def lambda_echo_function(self, value):
         self._lambda_echo_function = value
 
-    def attach_alias_to_version(self, version_obj: aws_lambda.Version, alias: str):
+    def attach_alias_to_version(self, version_obj: aws_lambda.Version) -> (str, str):
         """
-        Attach the given Alias to the given version of lambda
+        Creates a version alias for the given version of the lambda
+
+        :return: The version alias string
         """
-        aws_lambda.Alias(self, alias, version=version_obj, alias_name=alias)
+        version_alias_associated_version = version_obj.version
+        version_alias_name = "integ_test_current_version_alias"
+        aws_lambda.Alias(
+            self,
+            "integ_test_lambda_current_version_alias",
+            version=version_obj,
+            alias_name=version_alias_name
+        )
+        return version_alias_associated_version, version_alias_name
 
     def create_version(self, lambda_function: aws_lambda.IFunction, version: str):
         # MARK: this feature is deprecated and each stack deploy operation

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/lambda_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/lambda_stack.py
@@ -27,7 +27,9 @@ class LambdaStack(RegionAwareStack):
             ),
         )
 
-        version_alias_associated_version, version_alias_name = self.attach_alias_to_version(echo.current_version)
+        version_alias_associated_version, version_alias_name = self.attach_alias_to_version(
+            echo.current_version
+        )
 
         echo2 = aws_lambda.Function(
             self,
@@ -69,7 +71,7 @@ class LambdaStack(RegionAwareStack):
             self,
             "integ_test_lambda_current_version_alias",
             version=version_obj,
-            alias_name=version_alias_name
+            alias_name=version_alias_name,
         )
         return version_alias_associated_version, version_alias_name
 

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/mobileclient_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/mobileclient_stack.py
@@ -1,4 +1,4 @@
-from aws_cdk import aws_cognito, aws_iam, core
+from aws_cdk import aws_cognito, aws_iam, core, custom_resources
 
 from common.auth_utils import construct_identity_pool
 from common.common_stack import CommonStack
@@ -23,31 +23,87 @@ class MobileClientStack(RegionAwareStack):
             auto_verify=aws_cognito.AutoVerifiedAttrs(email=True),
         )
 
-        user_pool_client = aws_cognito.UserPoolClient(
-            self, "userpool_client", generate_secret=False, user_pool=user_pool
+        user_pool_client = aws_cognito.CfnUserPoolClient(
+            self, "userpool_client", generate_secret=True, user_pool_id=user_pool.user_pool_id
         )
 
-        cognito_identity_providers = [
-            {
-                "clientId": user_pool_client.user_pool_client_id,
-                "providerName": user_pool.user_pool_provider_name,
-            }
-        ]
+        user_pool_client_secret = self.create_userpool_client_secret_custom_resource(
+            user_pool, user_pool_client
+        )
 
         (identity_pool, _, _) = construct_identity_pool(
             self,
             resource_id_prefix="mobileclient",
-            cognito_identity_providers=cognito_identity_providers,
+            cognito_identity_providers=[
+                {
+                    "clientId": user_pool_client.ref,
+                    "providerName": user_pool.user_pool_provider_name,
+                }
+            ],
         )
-
-        self._parameters_to_save = {
-            "userpool_id": user_pool.user_pool_id,
-            "pool_id_dev_auth": identity_pool.ref,
-        }
-        self.save_parameters_in_parameter_store(platform=Platform.IOS)
 
         stack_policy = aws_iam.PolicyStatement(
             effect=aws_iam.Effect.ALLOW, actions=["cognito-identity:*"], resources=["*"]
         )
 
         common_stack.add_to_common_role_policies(self, policy_to_add=stack_policy)
+
+        self._parameters_to_save = {
+            "userpool_id": user_pool.user_pool_id,
+            "pool_id_dev_auth": identity_pool.ref,
+            "email_address": "aws-mobile-sdk-dev+mc-integ-tests@amazon.com",
+        }
+
+        self.update_parameters_for_userpool(user_pool, user_pool_client, user_pool_client_secret)
+
+        self.save_parameters_in_parameter_store(platform=Platform.IOS)
+
+    def create_userpool_client_secret_custom_resource(
+        self, user_pool, user_pool_client
+    ) -> custom_resources.AwsCustomResource:
+        """
+        :return: an AwsCustomResource that provides access to the user pool client secret in the
+            response field `user_pool_client_secret`
+        """
+        resource = custom_resources.AwsCustomResource(
+            self,
+            "userpool_client_secret_custom_resource",
+            resource_type="Custom::UserPoolClientSecret",
+            policy=custom_resources.AwsCustomResourcePolicy.from_statements(
+                [
+                    aws_iam.PolicyStatement(
+                        effect=aws_iam.Effect.ALLOW,
+                        actions=["cognito-idp:DescribeUserPoolClient"],
+                        resources=[
+                            f"arn:aws:cognito-idp:{self.region}:{self.account}:userpool/{user_pool.user_pool_id}"  # noqa: E501
+                        ],
+                    )
+                ]
+            ),
+            on_create=custom_resources.AwsSdkCall(
+                physical_resource_id=custom_resources.PhysicalResourceId.of(user_pool_client.ref),
+                service="CognitoIdentityServiceProvider",
+                action="describeUserPoolClient",
+                output_path="UserPoolClient.ClientSecret",
+                parameters={"ClientId": user_pool_client.ref, "UserPoolId": user_pool.user_pool_id},
+            ),
+            on_update=custom_resources.AwsSdkCall(
+                physical_resource_id=custom_resources.PhysicalResourceId.of(user_pool_client.ref),
+                service="CognitoIdentityServiceProvider",
+                action="describeUserPoolClient",
+                output_path="UserPoolClient.ClientSecret",
+                parameters={"ClientId": user_pool_client.ref, "UserPoolId": user_pool.user_pool_id},
+            ),
+        )
+        return resource
+
+    def update_parameters_for_userpool(self, user_pool, user_pool_client, user_pool_client_secret):
+        self._parameters_to_save.update(
+            {
+                "CognitoUserPool/Default/PoolId": user_pool.user_pool_id,
+                "CognitoUserPool/Default/AppClientId": user_pool_client.ref,
+                "CognitoUserPool/Default/AppClientSecret": user_pool_client_secret.get_response_field(  # noqa: E501
+                    "UserPoolClient.ClientSecret"
+                ),
+            }
+        )

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/mobileclient_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/mobileclient_stack.py
@@ -1,4 +1,4 @@
-from aws_cdk import aws_cognito, aws_iam, core, custom_resources
+from aws_cdk import aws_cognito, aws_iam, aws_s3, core, custom_resources
 
 from common.auth_utils import construct_identity_pool
 from common.common_stack import CommonStack
@@ -10,6 +10,8 @@ class MobileClientStack(RegionAwareStack):
     def __init__(self, scope: core.Construct, id: str, common_stack: CommonStack, **kwargs) -> None:
 
         super().__init__(scope, id, **kwargs)
+
+        self._parameters_to_save["email_address"] = "aws-mobile-sdk-dev+mc-integ-tests@amazon.com"
 
         self._supported_in_region = self.are_services_supported_in_region(
             ["cognito-identity", "cognito-idp"]
@@ -26,13 +28,13 @@ class MobileClientStack(RegionAwareStack):
             default_user_pool, default_user_pool_client, default_user_pool_client_secret, "Default"
         )
 
-        (identity_pool, _, _) = construct_identity_pool(
+        (identity_pool, auth_role, unauth_role) = construct_identity_pool(
             self,
             resource_id_prefix="mobileclient",
             cognito_identity_providers=[
                 {
                     "clientId": default_user_pool_client.ref,
-                    "providerName": default_user_pool.user_pool_provider_name,
+                    "providerName": f"cognito-idp.{self.region}.amazonaws.com/{default_user_pool.ref}",
                 }
             ],
         )
@@ -52,16 +54,64 @@ class MobileClientStack(RegionAwareStack):
             "DefaultCustomAuth",
         )
 
-        self._parameters_to_save["email_address"] = "aws-mobile-sdk-dev+mc-integ-tests@amazon.com"
+        s3_bucket = self.create_s3_bucket_and_policies(auth_role, unauth_role)
+        self.update_parameters_for_s3_bucket(s3_bucket)
+
         self.save_parameters_in_parameter_store(platform=Platform.IOS)
 
+    def create_s3_bucket_and_policies(
+        self, auth_role: aws_iam.Role, unauth_role: aws_iam.Role
+    ) -> aws_s3.Bucket:
+        """
+        Creates an S3 bucket and storage policies that mimic Amplify configurations
+
+        :param auth_role: The IAM role adopted by authenticated users the Identity Pool
+        :param unauth_role: The IAM role adopted by unauthenticated users the Identity Pool
+        :return: the S3 Bucket
+        """
+        bucket = aws_s3.Bucket(self, "integ_test_mobileclient_bucket")
+        MobileClientStack.add_public_policy(bucket, unauth_role, False)
+        MobileClientStack.add_read_policy(bucket, unauth_role)
+        MobileClientStack.add_list_policy(bucket, unauth_role, False)
+
+        MobileClientStack.add_public_policy(bucket, auth_role, True)
+        MobileClientStack.add_read_policy(bucket, auth_role)
+        MobileClientStack.add_list_policy(bucket, auth_role, True)
+        MobileClientStack.add_user_specific_policy(bucket, auth_role, "protected")
+        MobileClientStack.add_user_specific_policy(bucket, auth_role, "private")
+        MobileClientStack.add_uploads_policy(bucket, auth_role)
+
+        return bucket
+
     def create_user_pool(self, tag) -> aws_cognito.UserPool:
-        user_pool = aws_cognito.UserPool(
+        user_pool = aws_cognito.CfnUserPool(
             self,
             f"userpool_{tag}",
-            required_attributes=aws_cognito.RequiredAttributes(email=True),
-            self_sign_up_enabled=True,
-            auto_verify=aws_cognito.AutoVerifiedAttrs(email=True),
+            auto_verified_attributes=["email"],
+            device_configuration=aws_cognito.CfnUserPool.DeviceConfigurationProperty(
+                challenge_required_on_new_device=False,
+                device_only_remembered_on_user_prompt=True
+            ),
+            schema=[
+                aws_cognito.CfnUserPool.SchemaAttributeProperty(
+                    attribute_data_type="String",
+                    mutable=False,
+                    name="email",
+                    required=True,
+                ),
+                aws_cognito.CfnUserPool.SchemaAttributeProperty(
+                    attribute_data_type="String",
+                    mutable=True,
+                    name="mutableStringAttr1",
+                    required=False,
+                ),
+                aws_cognito.CfnUserPool.SchemaAttributeProperty(
+                    attribute_data_type="String",
+                    mutable=True,
+                    name="mutableStringAttr2",
+                    required=False,
+                )
+            ],
         )
         return user_pool
 
@@ -70,7 +120,7 @@ class MobileClientStack(RegionAwareStack):
             self,
             f"userpool_client_{tag}",
             generate_secret=True,
-            user_pool_id=user_pool.user_pool_id,
+            user_pool_id=user_pool.ref,
         )
         return user_pool_client
 
@@ -91,8 +141,7 @@ class MobileClientStack(RegionAwareStack):
                         effect=aws_iam.Effect.ALLOW,
                         actions=["cognito-idp:DescribeUserPoolClient"],
                         resources=[
-                            f"arn:aws:cognito-idp:{self.region}:{self.account}:userpool/{user_pool.user_pool_id}"
-                            # noqa: E501
+                            f"arn:aws:cognito-idp:{self.region}:{self.account}:userpool/{user_pool.ref}"  # noqa: E501
                         ],
                     )
                 ]
@@ -102,14 +151,14 @@ class MobileClientStack(RegionAwareStack):
                 service="CognitoIdentityServiceProvider",
                 action="describeUserPoolClient",
                 output_path="UserPoolClient.ClientSecret",
-                parameters={"ClientId": user_pool_client.ref, "UserPoolId": user_pool.user_pool_id},
+                parameters={"ClientId": user_pool_client.ref, "UserPoolId": user_pool.ref},
             ),
             on_update=custom_resources.AwsSdkCall(
                 physical_resource_id=custom_resources.PhysicalResourceId.of(user_pool_client.ref),
                 service="CognitoIdentityServiceProvider",
                 action="describeUserPoolClient",
                 output_path="UserPoolClient.ClientSecret",
-                parameters={"ClientId": user_pool_client.ref, "UserPoolId": user_pool.user_pool_id},
+                parameters={"ClientId": user_pool_client.ref, "UserPoolId": user_pool.ref},
             ),
         )
         return resource
@@ -133,7 +182,7 @@ class MobileClientStack(RegionAwareStack):
     ):
         self._parameters_to_save.update(
             {
-                f"awsconfiguration/CognitoUserPool/{tag}/PoolId": user_pool.user_pool_id,
+                f"awsconfiguration/CognitoUserPool/{tag}/PoolId": user_pool.ref,
                 f"awsconfiguration/CognitoUserPool/{tag}/AppClientId": user_pool_client.ref,
                 f"awsconfiguration/CognitoUserPool/{tag}/AppClientSecret": user_pool_client_secret.get_response_field(  # noqa: E501
                     "UserPoolClient.ClientSecret"
@@ -141,3 +190,71 @@ class MobileClientStack(RegionAwareStack):
                 f"awsconfiguration/CognitoUserPool/{tag}/Region": self.region,
             }
         )
+
+    def update_parameters_for_s3_bucket(self, bucket):
+        self._parameters_to_save.update(
+            {
+                "awsconfiguration/S3TransferUtility/Default/Bucket": bucket.bucket_name,
+                "awsconfiguration/S3TransferUtility/Default/Region": self.region,
+            }
+        )
+
+    @staticmethod
+    def add_public_policy(bucket, role: aws_iam.Role, is_auth_role):
+        actions = ["s3:GetObject"]
+        if is_auth_role:
+            actions.extend(["s3:PutObject", "s3:DeleteObject"])
+        policy = aws_iam.PolicyStatement(
+            effect=aws_iam.Effect.ALLOW,
+            actions=actions,
+            resources=[f"arn:aws:s3:::{bucket.bucket_name}/public/*"],
+        )
+        role.add_to_policy(policy)
+
+    @staticmethod
+    def add_read_policy(bucket, role: aws_iam.Role):
+        policy = aws_iam.PolicyStatement(
+            effect=aws_iam.Effect.ALLOW,
+            actions=["s3:GetObject"],
+            resources=[f"arn:aws:s3:::{bucket.bucket_name}/protected/*"],
+        )
+        role.add_to_policy(policy)
+
+    @staticmethod
+    def add_list_policy(bucket, role: aws_iam.Role, is_auth_role):
+        policy = aws_iam.PolicyStatement(
+            effect=aws_iam.Effect.ALLOW,
+            actions=["s3:ListBucket"],
+            resources=[f"arn:aws:s3:::{bucket.bucket_name}"],
+        )
+
+        prefixes = ["public/", "public/*", "protected/", "protected/*"]
+        if is_auth_role:
+            prefixes.extend(
+                [
+                    "private/${cognito-identity.amazonaws.com:sub}/",
+                    "private/${cognito-identity.amazonaws.com:sub}/*",
+                ]
+            )
+        policy.add_conditions({"StringLike": {"s3:prefix": prefixes}})
+        role.add_to_policy(policy)
+
+    @staticmethod
+    def add_user_specific_policy(bucket, role: aws_iam.Role, prefix):
+        policy = aws_iam.PolicyStatement(
+            effect=aws_iam.Effect.ALLOW,
+            actions=["s3:GetObject", "s3:PutObject", "s3:DeleteObject"],
+            resources=[
+                f"arn:aws:s3:::{bucket.bucket_name}/{prefix}/${{cognito-identity.amazonaws.com:sub}}/*"  # noqa: E501
+            ],
+        )
+        role.add_to_policy(policy)
+
+    @staticmethod
+    def add_uploads_policy(bucket, role: aws_iam.Role):
+        policy = aws_iam.PolicyStatement(
+            effect=aws_iam.Effect.ALLOW,
+            actions=["s3:PutObject"],
+            resources=[f"arn:aws:s3:::{bucket.bucket_name}/uploads/*"],
+        )
+        role.add_to_policy(policy)

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/pinpoint_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/pinpoint_stack.py
@@ -11,21 +11,24 @@ class PinpointStack(RegionAwareStack):
 
         self._supported_in_region = self.is_service_supported_in_region()
 
-        app = aws_pinpoint.CfnApp(self, "integ_test_app", name="integ_test_app")
-
-        self._parameters_to_save = {"pinpointAppId": app.ref}
-        self.save_parameters_in_parameter_store(platform=Platform.IOS)
-
-        all_resources_arn = self.format_arn(resource="*", service=id)
-
-        stack_policy = aws_iam.PolicyStatement(
-            effect=aws_iam.Effect.ALLOW,
-            actions=[
-                "mobileanalytics:putEvents",
-                "mobiletargeting:PutEvents",
-                "mobiletargeting:UpdateEndpoint",
-            ],
-            resources=[all_resources_arn],
+        pinpoint_app = aws_pinpoint.CfnApp(
+            self, "integ_test_pinpoint_app", name="integ_test_pinpoint_app"
         )
+        self._parameters_to_save["app_id"] = pinpoint_app.ref
 
-        common_stack.add_to_common_role_policies(self, policy_to_add=stack_policy)
+        legacy_mobileanalytics_policy = aws_iam.PolicyStatement(
+            effect=aws_iam.Effect.ALLOW,
+            actions=["mobileanalytics:putEvents"],
+            resources=[self.format_arn(resource="*", service="mobileanalytics")],
+        )
+        common_stack.add_to_common_role_policies(self, policy_to_add=legacy_mobileanalytics_policy)
+
+        app_arn = f"arn:aws:mobiletargeting:{self.region}:{self.account}:apps/*"
+        app_policy = aws_iam.PolicyStatement(
+            effect=aws_iam.Effect.ALLOW,
+            actions=["mobiletargeting:PutEvents", "mobiletargeting:UpdateEndpoint"],
+            resources=[app_arn],
+        )
+        common_stack.add_to_common_role_policies(self, policy_to_add=app_policy)
+
+        self.save_parameters_in_parameter_store(platform=Platform.IOS)

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/pinpoint_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/pinpoint_stack.py
@@ -17,9 +17,7 @@ class PinpointStack(RegionAwareStack):
         self._parameters_to_save["app_id"] = pinpoint_app.ref
 
         legacy_mobileanalytics_policy = aws_iam.PolicyStatement(
-            effect=aws_iam.Effect.ALLOW,
-            actions=["mobileanalytics:PutEvents"],
-            resources=[*],
+            effect=aws_iam.Effect.ALLOW, actions=["mobileanalytics:PutEvents"], resources=["*"],
         )
         common_stack.add_to_common_role_policies(self, policy_to_add=legacy_mobileanalytics_policy)
 

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/pinpoint_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/pinpoint_stack.py
@@ -18,8 +18,8 @@ class PinpointStack(RegionAwareStack):
 
         legacy_mobileanalytics_policy = aws_iam.PolicyStatement(
             effect=aws_iam.Effect.ALLOW,
-            actions=["mobileanalytics:putEvents"],
-            resources=[self.format_arn(resource="*", service="mobileanalytics")],
+            actions=["mobileanalytics:PutEvents"],
+            resources=[*],
         )
         common_stack.add_to_common_role_policies(self, policy_to_add=legacy_mobileanalytics_policy)
 

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/polly_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/polly_stack.py
@@ -1,0 +1,52 @@
+from aws_cdk import aws_iam, aws_s3, core
+
+from common.common_stack import CommonStack
+from common.platforms import Platform
+from common.region_aware_stack import RegionAwareStack
+
+
+class PollyStack(RegionAwareStack):
+    def __init__(self, scope: core.Construct, id: str, common_stack: CommonStack, **kwargs) -> None:
+        super().__init__(scope, id, **kwargs)
+
+        self._supported_in_region = self.is_service_supported_in_region()
+
+        aws_s3.Bucket(
+            self,
+            "integ_test_polly_output_bucket",
+            bucket_name=self.polly_bucket_name
+        )
+        self._parameters_to_save["s3_output_bucket_name"] = self.polly_bucket_name
+
+        s3_output_bucket_policy = aws_iam.PolicyStatement(
+            effect=aws_iam.Effect.ALLOW,
+            actions=["s3:PutObject"],
+            resources=[f"arn:aws:s3:::{self.polly_bucket_name}/*"],
+        )
+        common_stack.add_to_common_role_policies(self, policy_to_add=s3_output_bucket_policy)
+
+        # Per https://docs.aws.amazon.com/polly/latest/dg/security_iam_service-with-iam.html:
+        # "Amazon Polly does not support specifying resource ARNs in a policy." This conflicts with
+        # documentation
+        all_resources_policy = aws_iam.PolicyStatement(
+            effect=aws_iam.Effect.ALLOW,
+            actions=[
+                "polly:DeleteLexicon",
+                "polly:GetSpeechSynthesisTask",
+                "polly:ListSpeechSynthesisTasks",
+                "polly:PutLexicon",
+                "polly:StartSpeechSynthesisTask",
+                "polly:SynthesizeSpeech",
+            ],
+            resources=["*"],
+        )
+        common_stack.add_to_common_role_policies(self, policy_to_add=all_resources_policy)
+
+        self.save_parameters_in_parameter_store(platform=Platform.IOS)
+
+    # Ideally we'd do this by simply creating the bucket dynamically, but subsequently referring to
+    # the bucket causes a circular reference between the common and polly stacks
+    @property
+    def polly_bucket_name(self):
+        bucket_name = f"integ-test-polly-output-bucket-{self.region}-{self.account}"
+        return bucket_name

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/polly_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/polly_stack.py
@@ -11,11 +11,7 @@ class PollyStack(RegionAwareStack):
 
         self._supported_in_region = self.is_service_supported_in_region()
 
-        aws_s3.Bucket(
-            self,
-            "integ_test_polly_output_bucket",
-            bucket_name=self.polly_bucket_name
-        )
+        aws_s3.Bucket(self, "integ_test_polly_output_bucket", bucket_name=self.polly_bucket_name)
         self._parameters_to_save["s3_output_bucket_name"] = self.polly_bucket_name
 
         s3_output_bucket_policy = aws_iam.PolicyStatement(

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/rekognition_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/rekognition_stack.py
@@ -1,0 +1,18 @@
+from aws_cdk import aws_iam, core
+
+from common.common_stack import CommonStack
+from common.region_aware_stack import RegionAwareStack
+
+
+class RekognitionStack(RegionAwareStack):
+    def __init__(self, scope: core.Construct, id: str, common_stack: CommonStack, **kwargs) -> None:
+        super().__init__(scope, id, **kwargs)
+
+        self._supported_in_region = self.is_service_supported_in_region()
+
+        collection_policy = aws_iam.PolicyStatement(
+            effect=aws_iam.Effect.ALLOW,
+            actions=["rekognition:CreateCollection", "rekognition:IndexFaces"],
+            resources=[f"arn:aws:rekognition:{self.region}:{self.account}:collection/*"],
+        )
+        common_stack.add_to_common_role_policies(self, policy_to_add=collection_policy)

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/s3_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/s3_stack.py
@@ -1,0 +1,82 @@
+import hashlib
+
+from aws_cdk import aws_iam, aws_s3, core
+
+from common.common_stack import CommonStack
+from common.platforms import Platform
+from common.region_aware_stack import RegionAwareStack
+
+
+class S3Stack(RegionAwareStack):
+    def __init__(self, scope: core.Construct, id: str, common_stack: CommonStack, **kwargs) -> None:
+        super().__init__(scope, id, **kwargs)
+
+        self._supported_in_region = self.is_service_supported_in_region()
+
+        bucket_suffix = self.get_bucket_suffix()
+
+        bucket_name_prefix = self.create_dynamic_bucket_prefix(bucket_suffix)
+        bucket_name_basic = self.create_basic_bucket(bucket_suffix)
+        bucket_name_periods = self.create_period_bucket(bucket_suffix)
+        bucket_name_transfer_acceleration = self.create_transfer_accelerated_bucket(bucket_suffix)
+
+        bucket_resources_policy = aws_iam.PolicyStatement(
+            effect=aws_iam.Effect.ALLOW,
+            actions=["s3:*"],
+            resources=[
+                f"arn:aws:s3:::{bucket_name_prefix}*",
+                f"arn:aws:s3:::{bucket_name_prefix}*/*",
+                f"arn:aws:s3:::{bucket_name_basic}",
+                f"arn:aws:s3:::{bucket_name_basic}/*",
+                f"arn:aws:s3:::{bucket_name_periods}",
+                f"arn:aws:s3:::{bucket_name_periods}/*",
+                f"arn:aws:s3:::{bucket_name_transfer_acceleration}",
+                f"arn:aws:s3:::{bucket_name_transfer_acceleration}/*",
+            ],
+        )
+        common_stack.add_to_common_role_policies(self, policy_to_add=bucket_resources_policy)
+
+        all_resources_policy = aws_iam.PolicyStatement(
+            effect=aws_iam.Effect.ALLOW, actions=["s3:ListAllMyBuckets"], resources=["*"]
+        )
+        common_stack.add_to_common_role_policies(self, policy_to_add=all_resources_policy)
+
+        self.save_parameters_in_parameter_store(platform=Platform.IOS)
+
+    def create_dynamic_bucket_prefix(self, bucket_suffix) -> str:
+        bucket_name_prefix = f"integ-test-s3-{bucket_suffix}"
+        self._parameters_to_save["bucket_name_prefix"] = bucket_name_prefix
+        return bucket_name_prefix
+
+    def create_basic_bucket(self, bucket_suffix) -> str:
+        bucket_name = f"integ-test-s3-basic-{bucket_suffix}"
+        aws_s3.Bucket(self, "integ_test_s3_bucket_basic", bucket_name=bucket_name)
+        self._parameters_to_save["bucket_name_basic"] = bucket_name
+        return bucket_name
+
+    def create_period_bucket(self, bucket_suffix) -> str:
+        bucket_name = f"integ-test-s3.period.{bucket_suffix}"
+        aws_s3.Bucket(self, "integ_test_s3_bucket_periods", bucket_name=bucket_name)
+        self._parameters_to_save["bucket_name_with_periods"] = bucket_name
+        return bucket_name
+
+    def create_transfer_accelerated_bucket(self, bucket_suffix) -> str:
+        bucket_name = f"integ-test-s3-accel-{bucket_suffix}"
+        # As of this writing (2020-05-11), The Bucket object does not expose transfer acceleration
+        aws_s3.CfnBucket(
+            self,
+            "integ_test_s3_bucket_transfer_acceleration",
+            bucket_name=bucket_name,
+            accelerate_configuration={"accelerationStatus": "Enabled"},
+        )
+        self._parameters_to_save["bucket_name_transfer_acceleration"] = bucket_name
+        return bucket_name
+
+    def get_bucket_suffix(self) -> str:
+        """
+        :return: a string suitable for appending to a bucket name
+        """
+        token_string = f"{self.region}-{self.account}"
+        hash_result = hashlib.md5(token_string.encode())
+        digest_string = hash_result.hexdigest()
+        return digest_string


### PR DESCRIPTION
Added new stacks to support more iOS integ tests.

In addition:
- Initialized `_parameters_to_save` in the base `RegionAwareStack` class, to normalize the call site patterns to add values incrementally instead of having to remember to initialize it
- Addressed minor feedback from a previous PR, plus some other minor feedback

Note the use of the `AwsCustomResource` in `mobileclient`. I only recently discovered this, but it's a useful feature for modeling arbitrary API calls during CDK create, update, and delete operations. It's not a panacea for all the CDK gaps, but it was super handy when I needed to get the client secret from the UserPoolClient.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
