### PR TITLE
More iOS stacks

### DIFF
--- a/src/integ_test_resources/common/common_stack.py
+++ b/src/integ_test_resources/common/common_stack.py
@@ -70,7 +70,7 @@ class CommonStack(RegionAwareStack):
         self.parameters_to_save["identityPoolId"] = cognito_identity_pool.ref
         self.parameters_to_save["authRoleArn"] = cognito_identity_pool_auth_role.role_arn
         self.parameters_to_save["unauthRoleArn"] = cognito_identity_pool_unauth_role.role_arn
-        self.parameters_to_save["region"] = os.environ["AWS_DEFAULT_REGION"]
+        self.parameters_to_save["region"] = self.node.try_get_context("region")
 
     @property
     def circleci_execution_role(self) -> aws_iam.Role:

--- a/src/integ_test_resources/common/common_stack.py
+++ b/src/integ_test_resources/common/common_stack.py
@@ -1,3 +1,4 @@
+import hashlib
 import os
 
 from aws_cdk import aws_cognito, aws_iam, core

--- a/src/integ_test_resources/common/common_stack.py
+++ b/src/integ_test_resources/common/common_stack.py
@@ -1,5 +1,3 @@
-import os
-
 from aws_cdk import aws_cognito, aws_iam, core
 
 from common.auth_utils import construct_identity_pool

--- a/src/integ_test_resources/common/common_stack.py
+++ b/src/integ_test_resources/common/common_stack.py
@@ -1,4 +1,3 @@
-import hashlib
 import os
 
 from aws_cdk import aws_cognito, aws_iam, core

--- a/src/integ_test_resources/common/parameter_store.py
+++ b/src/integ_test_resources/common/parameter_store.py
@@ -1,6 +1,29 @@
+from typing import List, Union
+
 from aws_cdk import aws_ssm, core
 
 from common.platforms import Platform
+
+
+def save_parameter(
+    scope: core.Stack, key: str, value: Union[str, List[str]], platform: Platform
+) -> None:
+    """
+    Saves a parameter to the Amazon Systems Manager Parameter Store. The value
+    can be either a scalar string or a list of string
+    This method saves the given value under a key. Scopes passed to this method
+    must include a `stack` attribute which is used in forming the fully
+    qualified parameter name.
+    The fully qualified parameter name will always start with mobile-sdk and
+    android, followed by the stack name, and the passed key name. For example,
+    if the apigateway stack calls save_parameter with a key name of api_name,
+    the resulting fully qualified parameter name would be:
+    /mobile-sdk/android/apigateway/api_name
+    """
+    if type(value) is list:
+        save_string_list_parameter(scope, key, value, platform)
+    else:
+        save_string_parameter(scope, key, value, platform)
 
 
 def save_string_parameter(scope: core.Stack, key: str, value: str, platform: Platform) -> None:
@@ -16,14 +39,46 @@ def save_string_parameter(scope: core.Stack, key: str, value: str, platform: Pla
     /mobile-sdk/android/apigateway/api_name
     """
 
-    # Parameter names cannot be prefixed with the token 'aws', thus it is
-    # conspicuously absent from the namespace. See: https://amzn.to/2VDaqtC
-    NAMESPACE = ("mobile-sdk", platform.value)
-
-    tail = (scope.stack_name, key)
     resource_id = "param_" + key
-    parameter_name = "/" + "/".join(NAMESPACE + tail)
+    parameter_name = _get_parameter_name(platform, scope, key)
 
     aws_ssm.StringParameter(
         scope, resource_id, string_value=value, parameter_name=parameter_name, simple_name=False
     )
+
+
+def save_string_list_parameter(
+    scope: core.Stack, key: str, value: [str], platform: Platform
+) -> None:
+    """
+    Saves a string list parameter to the Amazon Systems Manager Parameter Store.
+    This method saves the given value under a key. Scopes passed to this method
+    must include a `stack` attribute which is used in forming the fully
+    qualified parameter name.
+    The fully qualified parameter name will always start with mobile-sdk and
+    android, followed by the stack name, and the passed key name. For example,
+    if the apigateway stack calls save_parameter with a key name of api_name,
+    the resulting fully qualified parameter name would be:
+    /mobile-sdk/android/apigateway/api_name
+    """
+
+    resource_id = "param_" + key
+    parameter_name = _get_parameter_name(platform, scope, key)
+
+    aws_ssm.StringListParameter(
+        scope,
+        resource_id,
+        string_list_value=value,
+        parameter_name=parameter_name,
+        simple_name=False
+    )
+
+
+def _get_parameter_name(platform: Platform, scope: core.Stack, key: str) -> str:
+    # Parameter names cannot be prefixed with the token 'aws', thus it is
+    # conspicuously absent from the namespace. See: https://amzn.to/2VDaqtC
+    namespace = ("mobile-sdk", platform.value)
+
+    tail = (scope.stack_name, key)
+    parameter_name = "/" + "/".join(namespace + tail)
+    return parameter_name

--- a/src/integ_test_resources/common/parameter_store.py
+++ b/src/integ_test_resources/common/parameter_store.py
@@ -70,7 +70,7 @@ def save_string_list_parameter(
         resource_id,
         string_list_value=value,
         parameter_name=parameter_name,
-        simple_name=False
+        simple_name=False,
     )
 
 

--- a/src/integ_test_resources/common/region_aware_stack.py
+++ b/src/integ_test_resources/common/region_aware_stack.py
@@ -4,7 +4,7 @@ import os
 from aws_cdk import core
 from boto3.session import Session
 
-from common.parameter_store import save_string_parameter
+from common.parameter_store import save_parameter
 from common.platforms import Platform
 
 
@@ -46,9 +46,8 @@ class RegionAwareStack(core.Stack):
         return services_supported_in_region
 
     def save_parameters_in_parameter_store(self, platform: Platform) -> None:
-
         for parameter_name, parameter_value in self.parameters_to_save.items():
-            save_string_parameter(self, parameter_name, parameter_value, platform=platform)
+            save_parameter(self, parameter_name, parameter_value, platform=platform)
 
     def add_dependencies_with_region_filter(self, stacks_to_add: list) -> None:
         for stack in stacks_to_add:

--- a/src/integ_test_resources/common/region_aware_stack.py
+++ b/src/integ_test_resources/common/region_aware_stack.py
@@ -1,5 +1,4 @@
 import hashlib
-import os
 
 from aws_cdk import core
 from boto3.session import Session

--- a/src/integ_test_resources/common/region_aware_stack.py
+++ b/src/integ_test_resources/common/region_aware_stack.py
@@ -14,6 +14,7 @@ class RegionAwareStack(core.Stack):
 
         self._supported_in_region: bool
         self._parameters_to_save = {}
+        self._id = id
 
     def is_service_supported_in_region(
         self, service_name: str = None, region_name: str = None
@@ -61,6 +62,10 @@ class RegionAwareStack(core.Stack):
     @property
     def parameters_to_save(self) -> dict:
         return self._parameters_to_save
+
+    @property
+    def id(self) -> str:
+        return self._id
 
     def get_bucket_name(self, tag) -> str:
         """

--- a/src/integ_test_resources/common/region_aware_stack.py
+++ b/src/integ_test_resources/common/region_aware_stack.py
@@ -22,7 +22,7 @@ class RegionAwareStack(core.Stack):
 
         boto3_session = Session()
         if region_name is None:
-            region_name = os.environ["AWS_DEFAULT_REGION"]
+            region_name = self.node.try_get_context("region")
 
         if service_name is None:
             service_name = self.stack_name

--- a/src/integ_test_resources/common/scripts/device_config_builder.py
+++ b/src/integ_test_resources/common/scripts/device_config_builder.py
@@ -5,12 +5,12 @@ import os
 import pathlib
 import sys
 from collections import namedtuple
+from typing import List, Union
 
 import boto3
 
-from platforms import Platform
-
 sys.path.append(str(pathlib.Path(__file__).parent.absolute()) + "/..")
+from platforms import Platform
 
 SUPPORTED_PLATFORMS = [platform.value for platform in Platform]
 
@@ -44,7 +44,7 @@ class DeviceConfigBuilder:
         for parameter in parameters:
             prefix_len = len(prefix)
             name = parameter["Name"][prefix_len:]
-            value = parameter["Value"]
+            value = DeviceConfigBuilder.get_value_for_parameter(parameter)
             self.add_package_data(all_packages_data, name, value)
         return all_packages_data
 
@@ -84,6 +84,15 @@ class DeviceConfigBuilder:
             if first_part not in all_package_data:
                 all_package_data[first_part] = dict()
             self.add_package_data(all_package_data[first_part], the_rest, value)
+
+    @staticmethod
+    def get_value_for_parameter(parameter: dict) -> Union[str, List[str]]:
+        raw_value = parameter["Value"]
+        if parameter.get("Type", "String") == "StringList":
+            array_value = raw_value.split(",")
+            return array_value
+        else:
+            return raw_value
 
     def get_parameters_with_prefix(self, parameter_prefix: str, ssm) -> dict:
         """

--- a/src/integ_test_resources/common/scripts/device_config_builder.py
+++ b/src/integ_test_resources/common/scripts/device_config_builder.py
@@ -8,8 +8,9 @@ from collections import namedtuple
 
 import boto3
 
-sys.path.append(str(pathlib.Path(__file__).parent.absolute()) + "/..")
 from platforms import Platform
+
+sys.path.append(str(pathlib.Path(__file__).parent.absolute()) + "/..")
 
 SUPPORTED_PLATFORMS = [platform.value for platform in Platform]
 

--- a/src/integ_test_resources/common/scripts/test/device_config_builder_test.py
+++ b/src/integ_test_resources/common/scripts/test/device_config_builder_test.py
@@ -63,7 +63,11 @@ class TestDeviceConfigBuilder(unittest.TestCase):
 
     def test_build_package_data_with_string_list(self):
         params = [
-            {"Name": "/mobile-sdk/android/string_with_commas", "Type": "String", "Value": "foo,bar"},
+            {
+                "Name": "/mobile-sdk/android/string_with_commas",
+                "Type": "String",
+                "Value": "foo,bar",
+            },
             {"Name": "/mobile-sdk/android/string_list", "Type": "StringList", "Value": "foo,bar"},
         ]
         prefix = "/mobile-sdk/android"
@@ -71,11 +75,7 @@ class TestDeviceConfigBuilder(unittest.TestCase):
         package_data = self.underTest.build_package_data(prefix, params)
 
         self.assertEqual(
-            {
-                "string_with_commas": "foo,bar",
-                "string_list": ["foo", "bar"],
-            },
-            package_data,
+            {"string_with_commas": "foo,bar", "string_list": ["foo", "bar"]}, package_data,
         )
 
     def test_get_credential_data(self):

--- a/src/integ_test_resources/common/scripts/test/device_config_builder_test.py
+++ b/src/integ_test_resources/common/scripts/test/device_config_builder_test.py
@@ -7,8 +7,9 @@ import sys
 import unittest
 from unittest.mock import patch
 
-sys.path.append(str(pathlib.Path(__file__).parent.absolute()) + "/..")
 from device_config_builder import DeviceConfigBuilder
+
+sys.path.append(str(pathlib.Path(__file__).parent.absolute()) + "/..")
 
 
 class TestDeviceConfigBuilder(unittest.TestCase):

--- a/src/integ_test_resources/common/scripts/test/device_config_builder_test.py
+++ b/src/integ_test_resources/common/scripts/test/device_config_builder_test.py
@@ -7,9 +7,8 @@ import sys
 import unittest
 from unittest.mock import patch
 
-from device_config_builder import DeviceConfigBuilder
-
 sys.path.append(str(pathlib.Path(__file__).parent.absolute()) + "/..")
+from device_config_builder import DeviceConfigBuilder
 
 
 class TestDeviceConfigBuilder(unittest.TestCase):
@@ -37,8 +36,16 @@ class TestDeviceConfigBuilder(unittest.TestCase):
 
     def test_build_package_data_with_nesting(self):
         params = [
-            {"Name": "/mobile-sdk/android/suite/foo/bar/baz", "Value": "foo_bar_baz_val"},
-            {"Name": "/mobile-sdk/android/suite/potato/bar/baz", "Value": "potato_bar_baz_val"},
+            {
+                "Name": "/mobile-sdk/android/suite/foo/bar/baz",
+                "Type": "String",
+                "Value": "foo_bar_baz_val",
+            },
+            {
+                "Name": "/mobile-sdk/android/suite/potato/bar/baz",
+                "Type": "String",
+                "Value": "potato_bar_baz_val",
+            },
         ]
         prefix = "/mobile-sdk/android"
 
@@ -50,6 +57,23 @@ class TestDeviceConfigBuilder(unittest.TestCase):
                     "foo": {"bar": {"baz": "foo_bar_baz_val"}},
                     "potato": {"bar": {"baz": "potato_bar_baz_val"}},
                 }
+            },
+            package_data,
+        )
+
+    def test_build_package_data_with_string_list(self):
+        params = [
+            {"Name": "/mobile-sdk/android/string_with_commas", "Type": "String", "Value": "foo,bar"},
+            {"Name": "/mobile-sdk/android/string_list", "Type": "StringList", "Value": "foo,bar"},
+        ]
+        prefix = "/mobile-sdk/android"
+
+        package_data = self.underTest.build_package_data(prefix, params)
+
+        self.assertEqual(
+            {
+                "string_with_commas": "foo,bar",
+                "string_list": ["foo", "bar"],
             },
             package_data,
         )

--- a/src/integ_test_resources/common/secrets_manager.py
+++ b/src/integ_test_resources/common/secrets_manager.py
@@ -1,31 +1,23 @@
-import base64
+import json
 
 import boto3
-from botocore.exceptions import ClientError
 
 from common.platforms import Platform
 
 
-def get_integ_tests_secrets(platform: Platform) -> str:
-    secret_name = "{}_integ_tests_secrets".format(platform.value)
+def get_integ_tests_secrets(platform: Platform) -> dict:
+    secret_name = "integ_test_secrets_{}".format(platform.value)
     # using constant region as these secrets are static & created outside of this app
     region_name = "us-east-1"
 
-    # Create a Secrets Manager client
     session = boto3.session.Session()
     client = session.client(service_name="secretsmanager", region_name=region_name)
 
-    try:
-        get_secret_value_response = client.get_secret_value(SecretId=secret_name)
-    except ClientError as e:
-        # secret cannot be retrived. Throw exception and fail
-        raise e
-    else:
-        # Depending on whether the secret is a string or binary, one of these fields will be
-        # populated
-        if "SecretString" in get_secret_value_response:
-            secret = get_secret_value_response["SecretString"]
-            return secret
-        else:
-            decoded_binary_secret = base64.b64decode(get_secret_value_response["SecretBinary"])
-            return decoded_binary_secret
+    get_secret_value_response = client.get_secret_value(SecretId=secret_name)
+
+    if "SecretString" not in get_secret_value_response:
+        raise ValueError(f"Value of {secret_name} is not a string")
+
+    secret_string = get_secret_value_response["SecretString"]
+    secret_dict = json.loads(secret_string)
+    return secret_dict

--- a/src/integ_test_resources/ios/sdk/integration/cdk/app.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/app.py
@@ -25,6 +25,7 @@ from cdk_integration_tests_ios.s3_stack import S3Stack
 from cdk_integration_tests_ios.ses_stack import SesStack
 from cdk_integration_tests_ios.sns_stack import SnsStack
 from cdk_integration_tests_ios.sts_stack import StsStack
+from cdk_integration_tests_ios.textract_stack import TextractStack
 from common.common_stack import CommonStack
 from common.main_stack import MainStack
 from common.platforms import Platform
@@ -64,6 +65,7 @@ s3_stack = S3Stack(app, "s3", common_stack)
 ses_stack = SesStack(app, "ses", common_stack)
 sns_stack = SnsStack(app, "sns", common_stack)
 sts_stack = StsStack(app, "sts", common_stack)
+textract_stack = TextractStack(app, "textract", common_stack)
 
 stacks_in_app = [
     core_stack,
@@ -87,6 +89,7 @@ stacks_in_app = [
     ses_stack,
     sns_stack,
     sts_stack,
+    textract_stack,
 ]
 
 add_stack_dependency_on_common_stack(stacks_in_app=stacks_in_app, common_stack=common_stack)

--- a/src/integ_test_resources/ios/sdk/integration/cdk/app.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/app.py
@@ -67,7 +67,7 @@ stacks_in_app = [
     RekognitionStack(app, "rekognition", common_stack),
     S3Stack(app, "s3", common_stack),
     SesStack(app, "ses", common_stack),
-    SimpleDbStack(app, "simpledb", common_stack),
+    SimpleDbStack(app, "sdb", common_stack),
     SnsStack(app, "sns", common_stack),
     SqsStack(app, "sqs", common_stack),
     StsStack(app, "sts", common_stack),

--- a/src/integ_test_resources/ios/sdk/integration/cdk/app.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/app.py
@@ -22,6 +22,7 @@ from cdk_integration_tests_ios.pinpoint_stack import PinpointStack
 from cdk_integration_tests_ios.polly_stack import PollyStack
 from cdk_integration_tests_ios.rekognition_stack import RekognitionStack
 from cdk_integration_tests_ios.s3_stack import S3Stack
+from cdk_integration_tests_ios.ses_stack import SesStack
 from cdk_integration_tests_ios.sns_stack import SnsStack
 from cdk_integration_tests_ios.sts_stack import StsStack
 from common.common_stack import CommonStack
@@ -60,6 +61,7 @@ pinpoint_stack = PinpointStack(app, "pinpoint", common_stack)
 polly_stack = PollyStack(app, "polly", common_stack)
 rekognition_stack = RekognitionStack(app, "rekognition", common_stack)
 s3_stack = S3Stack(app, "s3", common_stack)
+ses_stack = SesStack(app, "ses", common_stack)
 sns_stack = SnsStack(app, "sns", common_stack)
 sts_stack = StsStack(app, "sts", common_stack)
 
@@ -82,6 +84,7 @@ stacks_in_app = [
     polly_stack,
     rekognition_stack,
     s3_stack,
+    ses_stack,
     sns_stack,
     sts_stack,
 ]

--- a/src/integ_test_resources/ios/sdk/integration/cdk/app.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/app.py
@@ -40,7 +40,9 @@ app = core.App()
 region = app.node.try_get_context("region")
 account = app.node.try_get_context("account")
 if region is None or account is None:
-    raise ValueError("Provide region and account in 'context' parameter, as in: cdk deploy app -c region=us-west-2 -c account=123456")  # noqa: E501
+    raise ValueError(
+        "Provide region and account in 'context' parameter, as in: cdk deploy app -c region=us-west-2 -c account=123456"  # noqa: E501
+    )
 
 common_stack = CommonStack(app, "common", platform=Platform.IOS)
 main_stack = MainStack(app, "main")

--- a/src/integ_test_resources/ios/sdk/integration/cdk/app.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/app.py
@@ -27,6 +27,7 @@ from cdk_integration_tests_ios.sns_stack import SnsStack
 from cdk_integration_tests_ios.sqs_stack import SqsStack
 from cdk_integration_tests_ios.sts_stack import StsStack
 from cdk_integration_tests_ios.textract_stack import TextractStack
+from cdk_integration_tests_ios.transcribe_stack import TranscribeStack
 from common.common_stack import CommonStack
 from common.main_stack import MainStack
 from common.platforms import Platform
@@ -68,6 +69,7 @@ sns_stack = SnsStack(app, "sns", common_stack)
 sqs_stack = SqsStack(app, "sqs", common_stack)
 sts_stack = StsStack(app, "sts", common_stack)
 textract_stack = TextractStack(app, "textract", common_stack)
+transcribe_stack = TranscribeStack(app, "transcribe", common_stack)
 
 stacks_in_app = [
     core_stack,

--- a/src/integ_test_resources/ios/sdk/integration/cdk/app.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/app.py
@@ -28,6 +28,7 @@ from cdk_integration_tests_ios.sqs_stack import SqsStack
 from cdk_integration_tests_ios.sts_stack import StsStack
 from cdk_integration_tests_ios.textract_stack import TextractStack
 from cdk_integration_tests_ios.transcribe_stack import TranscribeStack
+from cdk_integration_tests_ios.translate_stack import TranslateStack
 from common.common_stack import CommonStack
 from common.main_stack import MainStack
 from common.platforms import Platform
@@ -70,6 +71,7 @@ sqs_stack = SqsStack(app, "sqs", common_stack)
 sts_stack = StsStack(app, "sts", common_stack)
 textract_stack = TextractStack(app, "textract", common_stack)
 transcribe_stack = TranscribeStack(app, "transcribe", common_stack)
+translate_stack = TranslateStack(app, "translate", common_stack)
 
 stacks_in_app = [
     core_stack,
@@ -80,6 +82,8 @@ stacks_in_app = [
     comprehend_stack,
     dynamodb_stack,
     ec2_stack,
+    elb_stack,
+    firehose_stack,
     iot_stack,
     kinesis_stack,
     kinesisvideo_stack,
@@ -95,6 +99,8 @@ stacks_in_app = [
     sqs_stack,
     sts_stack,
     textract_stack,
+    transcribe_stack,
+    translate_stack,
 ]
 
 add_stack_dependency_on_common_stack(stacks_in_app=stacks_in_app, common_stack=common_stack)

--- a/src/integ_test_resources/ios/sdk/integration/cdk/app.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/app.py
@@ -24,6 +24,7 @@ from cdk_integration_tests_ios.rekognition_stack import RekognitionStack
 from cdk_integration_tests_ios.s3_stack import S3Stack
 from cdk_integration_tests_ios.ses_stack import SesStack
 from cdk_integration_tests_ios.sns_stack import SnsStack
+from cdk_integration_tests_ios.sqs_stack import SqsStack
 from cdk_integration_tests_ios.sts_stack import StsStack
 from cdk_integration_tests_ios.textract_stack import TextractStack
 from common.common_stack import CommonStack
@@ -64,6 +65,7 @@ rekognition_stack = RekognitionStack(app, "rekognition", common_stack)
 s3_stack = S3Stack(app, "s3", common_stack)
 ses_stack = SesStack(app, "ses", common_stack)
 sns_stack = SnsStack(app, "sns", common_stack)
+sqs_stack = SqsStack(app, "sqs", common_stack)
 sts_stack = StsStack(app, "sts", common_stack)
 textract_stack = TextractStack(app, "textract", common_stack)
 
@@ -88,6 +90,7 @@ stacks_in_app = [
     s3_stack,
     ses_stack,
     sns_stack,
+    sqs_stack,
     sts_stack,
     textract_stack,
 ]

--- a/src/integ_test_resources/ios/sdk/integration/cdk/app.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/app.py
@@ -37,6 +37,11 @@ from common.stack_utils import add_stack_dependency_on_common_stack
 
 app = core.App()
 
+region = app.node.try_get_context("region")
+account = app.node.try_get_context("account")
+if region is None or account is None:
+    raise ValueError("Provide region and account in 'context' parameter, as in: cdk deploy app -c region=us-west-2 -c account=123456")  # noqa: E501
+
 common_stack = CommonStack(app, "common", platform=Platform.IOS)
 main_stack = MainStack(app, "main")
 main_stack.add_dependency(common_stack)

--- a/src/integ_test_resources/ios/sdk/integration/cdk/app.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/app.py
@@ -23,6 +23,7 @@ from cdk_integration_tests_ios.polly_stack import PollyStack
 from cdk_integration_tests_ios.rekognition_stack import RekognitionStack
 from cdk_integration_tests_ios.s3_stack import S3Stack
 from cdk_integration_tests_ios.ses_stack import SesStack
+from cdk_integration_tests_ios.simpledb_stack import SimpleDbStack
 from cdk_integration_tests_ios.sns_stack import SnsStack
 from cdk_integration_tests_ios.sqs_stack import SqsStack
 from cdk_integration_tests_ios.sts_stack import StsStack
@@ -44,63 +45,35 @@ core_stack = CoreStack(app, "core", common_stack)
 
 lambda_stack = LambdaStack(app, "lambda", common_stack)
 
-apigateway_stack = ApigatewayStack(
-    app, "apigateway", lambda_stack.lambda_echo_function, common_stack
-)
-
-autoscaling_stack = AutoScalingStack(app, "autoscaling", common_stack)
-cloudwatch_stack = CloudWatchStack(app, "cloudwatch", common_stack)
-cognito_idp_stack = CognitoIdpStack(app, "cognito-idp", common_stack)
-comprehend_stack = ComprehendStack(app, "comprehend", common_stack)
-dynamodb_stack = DynamoDbStack(app, "dynamodb", common_stack)
-ec2_stack = Ec2Stack(app, "ec2", common_stack)
-elb_stack = ElbStack(app, "elb", common_stack)
-firehose_stack = FirehoseStack(app, "firehose", common_stack)
-iot_stack = IotStack(app, "iot", common_stack)
-kinesis_stack = KinesisStack(app, "kinesis", common_stack)
-kinesisvideo_stack = KinesisVideoStack(app, "kinesisvideo", common_stack)
-kms_stack = KmsStack(app, "kms", common_stack)
-mobileclient_stack = MobileClientStack(app, "mobileclient", common_stack)
-pinpoint_stack = PinpointStack(app, "pinpoint", common_stack)
-polly_stack = PollyStack(app, "polly", common_stack)
-rekognition_stack = RekognitionStack(app, "rekognition", common_stack)
-s3_stack = S3Stack(app, "s3", common_stack)
-ses_stack = SesStack(app, "ses", common_stack)
-sns_stack = SnsStack(app, "sns", common_stack)
-sqs_stack = SqsStack(app, "sqs", common_stack)
-sts_stack = StsStack(app, "sts", common_stack)
-textract_stack = TextractStack(app, "textract", common_stack)
-transcribe_stack = TranscribeStack(app, "transcribe", common_stack)
-translate_stack = TranslateStack(app, "translate", common_stack)
-
 stacks_in_app = [
     core_stack,
-    apigateway_stack,
-    autoscaling_stack,
-    cloudwatch_stack,
-    cognito_idp_stack,
-    comprehend_stack,
-    dynamodb_stack,
-    ec2_stack,
-    elb_stack,
-    firehose_stack,
-    iot_stack,
-    kinesis_stack,
-    kinesisvideo_stack,
-    kms_stack,
     lambda_stack,
-    mobileclient_stack,
-    pinpoint_stack,
-    polly_stack,
-    rekognition_stack,
-    s3_stack,
-    ses_stack,
-    sns_stack,
-    sqs_stack,
-    sts_stack,
-    textract_stack,
-    transcribe_stack,
-    translate_stack,
+    ApigatewayStack(app, "apigateway", lambda_stack.lambda_echo_function, common_stack),
+    AutoScalingStack(app, "autoscaling", common_stack),
+    CloudWatchStack(app, "cloudwatch", common_stack),
+    CognitoIdpStack(app, "cognito-idp", common_stack),
+    ComprehendStack(app, "comprehend", common_stack),
+    DynamoDbStack(app, "dynamodb", common_stack),
+    Ec2Stack(app, "ec2", common_stack),
+    ElbStack(app, "elb", common_stack),
+    FirehoseStack(app, "firehose", common_stack),
+    IotStack(app, "iot", common_stack),
+    KinesisStack(app, "kinesis", common_stack),
+    KinesisVideoStack(app, "kinesisvideo", common_stack),
+    KmsStack(app, "kms", common_stack),
+    MobileClientStack(app, "mobileclient", common_stack),
+    PinpointStack(app, "pinpoint", common_stack),
+    PollyStack(app, "polly", common_stack),
+    RekognitionStack(app, "rekognition", common_stack),
+    S3Stack(app, "s3", common_stack),
+    SesStack(app, "ses", common_stack),
+    SimpleDbStack(app, "simpledb", common_stack),
+    SnsStack(app, "sns", common_stack),
+    SqsStack(app, "sqs", common_stack),
+    StsStack(app, "sts", common_stack),
+    TextractStack(app, "textract", common_stack),
+    TranscribeStack(app, "transcribe", common_stack),
+    TranslateStack(app, "translate", common_stack),
 ]
 
 add_stack_dependency_on_common_stack(stacks_in_app=stacks_in_app, common_stack=common_stack)

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/core_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/core_stack.py
@@ -1,5 +1,3 @@
-import json
-
 from aws_cdk import aws_cognito, aws_iam, core
 
 from common.auth_utils import construct_identity_pool
@@ -58,9 +56,9 @@ class CoreStack(RegionAwareStack):
 
     @staticmethod
     def get_facebook_app_config() -> (str, str):
-        ios_integ_tests_secrets = json.loads(get_integ_tests_secrets(platform=Platform.IOS))
-        facebook_app_id = ios_integ_tests_secrets["IOS_FB_AWSCORETESTS_APP_ID"]
-        facebook_app_secret = ios_integ_tests_secrets["IOS_FB_AWSCORETESTS_APP_SECRET"]
+        ios_integ_tests_secrets = get_integ_tests_secrets(platform=Platform.IOS)
+        facebook_app_id = ios_integ_tests_secrets["facebook.app_id"]
+        facebook_app_secret = ios_integ_tests_secrets["facebook.app_secret"]
         return facebook_app_id, facebook_app_secret
 
     def construct_identity_pool_with_facebook_as_idp(

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/firehose_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/firehose_stack.py
@@ -22,8 +22,7 @@ class FirehoseStack(RegionAwareStack):
         firehose_stream_name = firehose.ref
         self._parameters_to_save["firehose_stream_name"] = firehose_stream_name
 
-        firehose_arn = firehose.get_att("Arn").to_string()
-        self.create_test_policies(firehose_arn, common_stack)
+        self.create_test_policies(common_stack)
 
         self.save_parameters_in_parameter_store(Platform.IOS)
 
@@ -136,7 +135,7 @@ class FirehoseStack(RegionAwareStack):
         )
         return firehose
 
-    def create_test_policies(self, firehose_arn, common_stack):
+    def create_test_policies(self, common_stack):
         all_resources_policy = aws_iam.PolicyStatement(
             effect=aws_iam.Effect.ALLOW, actions=["firehose:ListDeliveryStreams"], resources=["*"],
         )
@@ -145,6 +144,6 @@ class FirehoseStack(RegionAwareStack):
         deliverystream_policy = aws_iam.PolicyStatement(
             effect=aws_iam.Effect.ALLOW,
             actions=["firehose:PutRecord", "firehose:PutRecordBatch"],
-            resources=[firehose_arn],
+            resources=[f"arn:aws:firehose:{self.region}:{self.account}:deliverystream/*"],
         )
         common_stack.add_to_common_role_policies(self, policy_to_add=deliverystream_policy)

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/firehose_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/firehose_stack.py
@@ -28,7 +28,7 @@ class FirehoseStack(RegionAwareStack):
 
     def create_s3_delivery_bucket(self) -> aws_s3.Bucket:
         delivery_bucket = aws_s3.Bucket(
-            self, "integ_test_firehose_delivery_bucket", removal_policy="DESTROY"
+            self, "integ_test_firehose_delivery_bucket", removal_policy=core.RemovalPolicy.DESTROY
         )
         return delivery_bucket
 
@@ -37,12 +37,15 @@ class FirehoseStack(RegionAwareStack):
             self,
             "integ_test_firehose_delivery_log_group",
             log_group_name=FirehoseStack.LOG_GROUP_NAME,
+            removal_policy=core.RemovalPolicy.DESTROY,
+            retention=aws_logs.RetentionDays.FIVE_DAYS,
         )
         aws_logs.LogStream(
             self,
             "integ_test_firehose_delivery_log_stream",
             log_group=log_group,
             log_stream_name=FirehoseStack.LOG_STREAM_NAME,
+            removal_policy=core.RemovalPolicy.DESTROY,
         )
         return log_group
 

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/firehose_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/firehose_stack.py
@@ -27,7 +27,9 @@ class FirehoseStack(RegionAwareStack):
         self.save_parameters_in_parameter_store(Platform.IOS)
 
     def create_s3_delivery_bucket(self) -> aws_s3.Bucket:
-        delivery_bucket = aws_s3.Bucket(self, "integ_test_firehose_delivery_bucket")
+        delivery_bucket = aws_s3.Bucket(
+            self, "integ_test_firehose_delivery_bucket", removal_policy="DESTROY"
+        )
         return delivery_bucket
 
     def create_log_group_and_stream(self) -> aws_logs.LogGroup:

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/iot_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/iot_stack.py
@@ -38,7 +38,7 @@ class IotStack(RegionAwareStack):
             handler="iot_endpoint_provider.on_event",
             description="Returns iot:Data-ATS endpoint for this account",
             current_version_options=aws_lambda.VersionOptions(
-                removal_policy=core.RemovalPolicy.RETAIN
+                removal_policy=core.RemovalPolicy.DESTROY
             ),
             initial_policy=[describe_endpoint_policy],
         )
@@ -179,7 +179,7 @@ class IotStack(RegionAwareStack):
             handler="iot_custom_authorizer_provider.on_event",
             description="Sets up an IoT custom authorizer",
             current_version_options=aws_lambda.VersionOptions(
-                removal_policy=core.RemovalPolicy.RETAIN
+                removal_policy=core.RemovalPolicy.DESTROY
             ),
             initial_policy=[create_authorizer_policy],
         )
@@ -220,7 +220,7 @@ class IotStack(RegionAwareStack):
             handler="iot_custom_authorizer.handler",
             description="Sample custom authorizer that allows or denies based on 'token' value",
             current_version_options=aws_lambda.VersionOptions(
-                removal_policy=core.RemovalPolicy.RETAIN
+                removal_policy=core.RemovalPolicy.DESTROY
             ),
             environment={"RESOURCE_ARN": f"arn:aws:iot:{self.region}:{self.account}:*"},
         )
@@ -252,7 +252,7 @@ class IotStack(RegionAwareStack):
             handler="iot_custom_authorizer_key_provider.on_event",
             description="Manages an asymmetric CMK and token signature for iot custom authorizer.",
             current_version_options=aws_lambda.VersionOptions(
-                removal_policy=core.RemovalPolicy.RETAIN
+                removal_policy=core.RemovalPolicy.DESTROY
             ),
             initial_policy=[create_authorizer_policy],
         )

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/lambda_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/lambda_stack.py
@@ -23,7 +23,7 @@ class LambdaStack(RegionAwareStack):
             handler="echo.handler",
             description=datetime.now().strftime("%d-%b-%Y (%H:%M:%S.%f)"),
             current_version_options=aws_lambda.VersionOptions(
-                removal_policy=core.RemovalPolicy.RETAIN
+                removal_policy=core.RemovalPolicy.DESTROY
             ),
         )
 

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/mobileclient_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/mobileclient_stack.py
@@ -35,7 +35,7 @@ class MobileClientStack(RegionAwareStack):
             cognito_identity_providers=[
                 {
                     "clientId": default_user_pool_client.ref,
-                    "providerName": f"cognito-idp.{self.region}.amazonaws.com/{default_user_pool.ref}",
+                    "providerName": f"cognito-idp.{self.region}.amazonaws.com/{default_user_pool.ref}",  # noqa: E501
                 }
             ],
         )
@@ -90,15 +90,11 @@ class MobileClientStack(RegionAwareStack):
             f"userpool_{tag}",
             auto_verified_attributes=["email"],
             device_configuration=aws_cognito.CfnUserPool.DeviceConfigurationProperty(
-                challenge_required_on_new_device=False,
-                device_only_remembered_on_user_prompt=True
+                challenge_required_on_new_device=False, device_only_remembered_on_user_prompt=True
             ),
             schema=[
                 aws_cognito.CfnUserPool.SchemaAttributeProperty(
-                    attribute_data_type="String",
-                    mutable=False,
-                    name="email",
-                    required=True,
+                    attribute_data_type="String", mutable=False, name="email", required=True,
                 ),
                 aws_cognito.CfnUserPool.SchemaAttributeProperty(
                     attribute_data_type="String",
@@ -111,17 +107,14 @@ class MobileClientStack(RegionAwareStack):
                     mutable=True,
                     name="mutableStringAttr2",
                     required=False,
-                )
+                ),
             ],
         )
         return user_pool
 
     def create_user_pool_client(self, user_pool, tag) -> aws_cognito.CfnUserPoolClient:
         user_pool_client = aws_cognito.CfnUserPoolClient(
-            self,
-            f"userpool_client_{tag}",
-            generate_secret=True,
-            user_pool_id=user_pool.ref,
+            self, f"userpool_client_{tag}", generate_secret=True, user_pool_id=user_pool.ref,
         )
         return user_pool_client
 

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/mobileclient_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/mobileclient_stack.py
@@ -94,7 +94,9 @@ class MobileClientStack(RegionAwareStack):
         :param unauth_role: The IAM role adopted by unauthenticated users the Identity Pool
         :return: the S3 Bucket
         """
-        bucket = aws_s3.Bucket(self, "integ_test_mobileclient_bucket", removal_policy="DESTROY")
+        bucket = aws_s3.Bucket(
+            self, "integ_test_mobileclient_bucket", removal_policy=core.RemovalPolicy.DESTROY
+        )
         MobileClientStack.add_public_policy(bucket, unauth_role, False)
         MobileClientStack.add_read_policy(bucket, unauth_role)
         MobileClientStack.add_list_policy(bucket, unauth_role, False)

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/mobileclient_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/mobileclient_stack.py
@@ -12,6 +12,7 @@ class MobileClientStack(RegionAwareStack):
         super().__init__(scope, id, **kwargs)
 
         self._parameters_to_save["email_address"] = "aws-mobile-sdk-dev+mc-integ-tests@amazon.com"
+        self._parameters_to_save["test_password"] = "Abc123@@!!"
 
         self._supported_in_region = self.are_services_supported_in_region(
             ["cognito-identity", "cognito-idp"]

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/mobileclient_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/mobileclient_stack.py
@@ -94,7 +94,7 @@ class MobileClientStack(RegionAwareStack):
         :param unauth_role: The IAM role adopted by unauthenticated users the Identity Pool
         :return: the S3 Bucket
         """
-        bucket = aws_s3.Bucket(self, "integ_test_mobileclient_bucket")
+        bucket = aws_s3.Bucket(self, "integ_test_mobileclient_bucket", removal_policy="DESTROY")
         MobileClientStack.add_public_policy(bucket, unauth_role, False)
         MobileClientStack.add_read_policy(bucket, unauth_role)
         MobileClientStack.add_list_policy(bucket, unauth_role, False)

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/mobileclient_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/mobileclient_stack.py
@@ -29,6 +29,7 @@ class MobileClientStack(RegionAwareStack):
         self.update_common_stack_with_test_policy(common_stack)
 
         default_user_pool = self.create_user_pool("default")
+        self.add_federation_to_user_pool(default_user_pool, "default")
         default_user_pool_client = self.create_user_pool_client(default_user_pool, "default", True)
         default_user_pool_client_secret = self.create_userpool_client_secret(
             default_user_pool, default_user_pool_client, "default"
@@ -125,6 +126,33 @@ class MobileClientStack(RegionAwareStack):
             ],
         )
         return user_pool
+
+    def add_federation_to_user_pool(self, user_pool: aws_cognito.CfnUserPool, tag: str):
+        aws_cognito.CfnUserPoolIdentityProvider(
+            self,
+            f"user_pool_idp_facebook_{tag}",
+            provider_name="Facebook",
+            provider_type="Facebook",
+            user_pool_id=user_pool.ref,
+            provider_details={
+                "client_id": "FB_CLIENT_1234567989",
+                "client_secret": "FB_CLIENT_SECRET_123456789",
+                "authorize_scopes": ["openid", "email"],
+                "api_version": "v7.0",
+            }
+        )
+        aws_cognito.CfnUserPoolIdentityProvider(
+            self,
+            f"user_pool_idp_facebook_{tag}",
+            provider_name="Google",
+            provider_type="Google",
+            user_pool_id=user_pool.ref,
+            provider_details={
+                "client_id": "GOOGLE_CLIENT_1234567989",
+                "client_secret": "GOOGLE_CLIENT_SECRET_123456789",
+                "authorize_scopes": ["openid", "email"],
+            }
+        )
 
     def create_user_pool_client(
         self, user_pool: aws_cognito.CfnUserPool, tag: str, include_federation: bool

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/polly_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/polly_stack.py
@@ -11,19 +11,8 @@ class PollyStack(RegionAwareStack):
 
         self._supported_in_region = self.is_service_supported_in_region()
 
-        aws_s3.Bucket(self, "integ_test_polly_output_bucket", bucket_name=self.polly_bucket_name)
-        self._parameters_to_save["s3_output_bucket_name"] = self.polly_bucket_name
+        self.create_bucket(common_stack)
 
-        s3_output_bucket_policy = aws_iam.PolicyStatement(
-            effect=aws_iam.Effect.ALLOW,
-            actions=["s3:PutObject"],
-            resources=[f"arn:aws:s3:::{self.polly_bucket_name}/*"],
-        )
-        common_stack.add_to_common_role_policies(self, policy_to_add=s3_output_bucket_policy)
-
-        # Per https://docs.aws.amazon.com/polly/latest/dg/security_iam_service-with-iam.html:
-        # "Amazon Polly does not support specifying resource ARNs in a policy." This conflicts with
-        # documentation
         all_resources_policy = aws_iam.PolicyStatement(
             effect=aws_iam.Effect.ALLOW,
             actions=[
@@ -40,9 +29,13 @@ class PollyStack(RegionAwareStack):
 
         self.save_parameters_in_parameter_store(platform=Platform.IOS)
 
-    # Ideally we'd do this by simply creating the bucket dynamically, but subsequently referring to
-    # the bucket causes a circular reference between the common and polly stacks
-    @property
-    def polly_bucket_name(self):
-        bucket_name = f"integ-test-polly-output-bucket-{self.region}-{self.account}"
-        return bucket_name
+    def create_bucket(self, common_stack):
+        bucket_name = self.get_bucket_name("output")
+        bucket = aws_s3.Bucket(self, "integ_test_polly_output_bucket", bucket_name=bucket_name)
+        self._parameters_to_save["s3_output_bucket_name"] = bucket.bucket_name
+        policy = aws_iam.PolicyStatement(
+            effect=aws_iam.Effect.ALLOW,
+            actions=["s3:PutObject"],
+            resources=[f"arn:aws:s3:::{bucket_name}/*"],
+        )
+        common_stack.add_to_common_role_policies(self, policy_to_add=policy)

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/polly_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/polly_stack.py
@@ -35,7 +35,7 @@ class PollyStack(RegionAwareStack):
             self,
             "integ_test_polly_output_bucket",
             bucket_name=bucket_name,
-            removal_policy="DESTROY"
+            removal_policy=core.RemovalPolicy.DESTROY,
         )
         self._parameters_to_save["s3_output_bucket_name"] = bucket.bucket_name
         policy = aws_iam.PolicyStatement(

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/polly_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/polly_stack.py
@@ -31,7 +31,12 @@ class PollyStack(RegionAwareStack):
 
     def create_bucket(self, common_stack):
         bucket_name = self.get_bucket_name("output")
-        bucket = aws_s3.Bucket(self, "integ_test_polly_output_bucket", bucket_name=bucket_name)
+        bucket = aws_s3.Bucket(
+            self,
+            "integ_test_polly_output_bucket",
+            bucket_name=bucket_name,
+            removal_policy="DESTROY"
+        )
         self._parameters_to_save["s3_output_bucket_name"] = bucket.bucket_name
         policy = aws_iam.PolicyStatement(
             effect=aws_iam.Effect.ALLOW,

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/s3_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/s3_stack.py
@@ -47,7 +47,10 @@ class S3Stack(RegionAwareStack):
     def create_basic_bucket(self) -> str:
         bucket_name = self.get_bucket_name("basic")
         aws_s3.Bucket(
-            self, "integ_test_s3_bucket_basic", bucket_name=bucket_name, removal_policy="DESTROY"
+            self,
+            "integ_test_s3_bucket_basic",
+            bucket_name=bucket_name,
+            removal_policy=core.RemovalPolicy.DESTROY,
         )
         self._parameters_to_save["bucket_name_basic"] = bucket_name
         return bucket_name
@@ -55,7 +58,10 @@ class S3Stack(RegionAwareStack):
     def create_period_bucket(self) -> str:
         bucket_name = self.get_bucket_name("period.test")
         aws_s3.Bucket(
-            self, "integ_test_s3_bucket_periods", bucket_name=bucket_name, removal_policy="DESTROY"
+            self,
+            "integ_test_s3_bucket_periods",
+            bucket_name=bucket_name,
+            removal_policy=core.RemovalPolicy.DESTROY,
         )
         self._parameters_to_save["bucket_name_with_periods"] = bucket_name
         return bucket_name
@@ -70,5 +76,5 @@ class S3Stack(RegionAwareStack):
             accelerate_configuration={"accelerationStatus": "Enabled"},
         )
         self._parameters_to_save["bucket_name_transfer_acceleration"] = bucket_name
-        bucket.apply_removal_policy("DESTROY")
+        bucket.apply_removal_policy(core.RemovalPolicy.DESTROY)
         return bucket_name

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/s3_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/s3_stack.py
@@ -13,12 +13,10 @@ class S3Stack(RegionAwareStack):
 
         self._supported_in_region = self.is_service_supported_in_region()
 
-        bucket_suffix = self.get_bucket_suffix()
-
-        bucket_name_prefix = self.create_dynamic_bucket_prefix(bucket_suffix)
-        bucket_name_basic = self.create_basic_bucket(bucket_suffix)
-        bucket_name_periods = self.create_period_bucket(bucket_suffix)
-        bucket_name_transfer_acceleration = self.create_transfer_accelerated_bucket(bucket_suffix)
+        bucket_name_prefix = self.create_dynamic_bucket_prefix()
+        bucket_name_basic = self.create_basic_bucket()
+        bucket_name_periods = self.create_period_bucket()
+        bucket_name_transfer_acceleration = self.create_transfer_accelerated_bucket()
 
         bucket_resources_policy = aws_iam.PolicyStatement(
             effect=aws_iam.Effect.ALLOW,
@@ -43,25 +41,25 @@ class S3Stack(RegionAwareStack):
 
         self.save_parameters_in_parameter_store(platform=Platform.IOS)
 
-    def create_dynamic_bucket_prefix(self, bucket_suffix) -> str:
-        bucket_name_prefix = f"integ-test-s3-{bucket_suffix}"
+    def create_dynamic_bucket_prefix(self) -> str:
+        bucket_name_prefix = self.get_bucket_name("")
         self._parameters_to_save["bucket_name_prefix"] = bucket_name_prefix
         return bucket_name_prefix
 
-    def create_basic_bucket(self, bucket_suffix) -> str:
-        bucket_name = f"integ-test-s3-basic-{bucket_suffix}"
+    def create_basic_bucket(self) -> str:
+        bucket_name = self.get_bucket_name("basic")
         aws_s3.Bucket(self, "integ_test_s3_bucket_basic", bucket_name=bucket_name)
         self._parameters_to_save["bucket_name_basic"] = bucket_name
         return bucket_name
 
-    def create_period_bucket(self, bucket_suffix) -> str:
-        bucket_name = f"integ-test-s3.period.{bucket_suffix}"
+    def create_period_bucket(self) -> str:
+        bucket_name = self.get_bucket_name("period.test")
         aws_s3.Bucket(self, "integ_test_s3_bucket_periods", bucket_name=bucket_name)
         self._parameters_to_save["bucket_name_with_periods"] = bucket_name
         return bucket_name
 
-    def create_transfer_accelerated_bucket(self, bucket_suffix) -> str:
-        bucket_name = f"integ-test-s3-accel-{bucket_suffix}"
+    def create_transfer_accelerated_bucket(self) -> str:
+        bucket_name = self.get_bucket_name("accel")
         # As of this writing (2020-05-11), The Bucket object does not expose transfer acceleration
         aws_s3.CfnBucket(
             self,
@@ -71,12 +69,3 @@ class S3Stack(RegionAwareStack):
         )
         self._parameters_to_save["bucket_name_transfer_acceleration"] = bucket_name
         return bucket_name
-
-    def get_bucket_suffix(self) -> str:
-        """
-        :return: a string suitable for appending to a bucket name
-        """
-        token_string = f"{self.region}-{self.account}"
-        hash_result = hashlib.md5(token_string.encode())
-        digest_string = hash_result.hexdigest()
-        return digest_string

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/s3_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/s3_stack.py
@@ -1,5 +1,3 @@
-import hashlib
-
 from aws_cdk import aws_iam, aws_s3, core
 
 from common.common_stack import CommonStack

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/s3_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/s3_stack.py
@@ -46,24 +46,29 @@ class S3Stack(RegionAwareStack):
 
     def create_basic_bucket(self) -> str:
         bucket_name = self.get_bucket_name("basic")
-        aws_s3.Bucket(self, "integ_test_s3_bucket_basic", bucket_name=bucket_name)
+        aws_s3.Bucket(
+            self, "integ_test_s3_bucket_basic", bucket_name=bucket_name, removal_policy="DESTROY"
+        )
         self._parameters_to_save["bucket_name_basic"] = bucket_name
         return bucket_name
 
     def create_period_bucket(self) -> str:
         bucket_name = self.get_bucket_name("period.test")
-        aws_s3.Bucket(self, "integ_test_s3_bucket_periods", bucket_name=bucket_name)
+        aws_s3.Bucket(
+            self, "integ_test_s3_bucket_periods", bucket_name=bucket_name, removal_policy="DESTROY"
+        )
         self._parameters_to_save["bucket_name_with_periods"] = bucket_name
         return bucket_name
 
     def create_transfer_accelerated_bucket(self) -> str:
         bucket_name = self.get_bucket_name("accel")
         # As of this writing (2020-05-11), The Bucket object does not expose transfer acceleration
-        aws_s3.CfnBucket(
+        bucket = aws_s3.CfnBucket(
             self,
             "integ_test_s3_bucket_transfer_acceleration",
             bucket_name=bucket_name,
             accelerate_configuration={"accelerationStatus": "Enabled"},
         )
         self._parameters_to_save["bucket_name_transfer_acceleration"] = bucket_name
+        bucket.apply_removal_policy("DESTROY")
         return bucket_name

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/ses_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/ses_stack.py
@@ -1,0 +1,18 @@
+from aws_cdk import aws_iam, core
+
+from common.common_stack import CommonStack
+from common.region_aware_stack import RegionAwareStack
+
+
+class SesStack(RegionAwareStack):
+    def __init__(self, scope: core.Construct, id: str, common_stack: CommonStack, **kwargs) -> None:
+        super().__init__(scope, id, **kwargs)
+
+        self._supported_in_region = self.is_service_supported_in_region()
+
+        all_resources_policy = aws_iam.PolicyStatement(
+            effect=aws_iam.Effect.ALLOW,
+            actions=["ses:GetSendQuota", "ses:VerifyEmailIdentity"],
+            resources=["*"],
+        )
+        common_stack.add_to_common_role_policies(self, policy_to_add=all_resources_policy)

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/simpledb_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/simpledb_stack.py
@@ -1,0 +1,35 @@
+from aws_cdk import aws_iam, core
+
+from common.common_stack import CommonStack
+from common.platforms import Platform
+from common.region_aware_stack import RegionAwareStack
+
+
+class SimpleDbStack(RegionAwareStack):
+    def __init__(self, scope: core.Construct, id: str, common_stack: CommonStack, **kwargs) -> None:
+        super().__init__(scope, id, **kwargs)
+
+        self._supported_in_region = self.is_service_supported_in_region()
+
+        domain_prefix = "integ_test_sdb_domain"
+        self.parameters_to_save["domain_prefix"] = domain_prefix
+
+        all_resources_policy = aws_iam.PolicyStatement(
+            effect=aws_iam.Effect.ALLOW,
+            actions=[
+                "sdb:BatchPutAttributes",
+                "sdb:CreateDomain",
+                "sdb:DeleteDomain",
+                "sdb:PutAttributes",
+                "sdb:Select",
+            ],
+            resources=[f"arn:aws:sdb:{self.region}:{self.account}:domain/{domain_prefix}*"],
+        )
+        common_stack.add_to_common_role_policies(self, policy_to_add=all_resources_policy)
+
+        all_resources_policy = aws_iam.PolicyStatement(
+            effect=aws_iam.Effect.ALLOW, actions=["sdb:ListDomains"], resources=["*"]
+        )
+        common_stack.add_to_common_role_policies(self, policy_to_add=all_resources_policy)
+
+        self.save_parameters_in_parameter_store(platform=Platform.IOS)

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/sqs_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/sqs_stack.py
@@ -1,0 +1,26 @@
+from aws_cdk import aws_iam, aws_sqs, core
+
+from common.common_stack import CommonStack
+from common.region_aware_stack import RegionAwareStack
+
+
+class SqsStack(RegionAwareStack):
+    def __init__(self, scope: core.Construct, id: str, common_stack: CommonStack, **kwargs) -> None:
+        super().__init__(scope, id, **kwargs)
+
+        self._supported_in_region = self.is_service_supported_in_region()
+
+        # Test simply asserts the existence of a queue
+        aws_sqs.Queue(self, "integ_test_sqs_queue")
+
+        queue_policy = aws_iam.PolicyStatement(
+            effect=aws_iam.Effect.ALLOW,
+            actions=["sqs:GetQueueAttributes"],
+            resources=[f"arn:aws:sqs:{self.region}:{self.account}:*"],
+        )
+        common_stack.add_to_common_role_policies(self, policy_to_add=queue_policy)
+
+        all_resources_policy = aws_iam.PolicyStatement(
+            effect=aws_iam.Effect.ALLOW, actions=["sqs:ListQueues"], resources=["*"],
+        )
+        common_stack.add_to_common_role_policies(self, policy_to_add=all_resources_policy)

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/textract_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/textract_stack.py
@@ -1,4 +1,4 @@
-from aws_cdk import aws_iam, aws_s3, core
+from aws_cdk import aws_iam, core
 
 from common.common_stack import CommonStack
 from common.platforms import Platform

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/textract_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/textract_stack.py
@@ -1,0 +1,19 @@
+from aws_cdk import aws_iam, aws_s3, core
+
+from common.common_stack import CommonStack
+from common.platforms import Platform
+from common.region_aware_stack import RegionAwareStack
+
+
+class TextractStack(RegionAwareStack):
+    def __init__(self, scope: core.Construct, id: str, common_stack: CommonStack, **kwargs) -> None:
+        super().__init__(scope, id, **kwargs)
+
+        self._supported_in_region = self.is_service_supported_in_region()
+
+        all_resources_policy = aws_iam.PolicyStatement(
+            effect=aws_iam.Effect.ALLOW, actions=["textract:AnalyzeDocument"], resources=["*"]
+        )
+        common_stack.add_to_common_role_policies(self, policy_to_add=all_resources_policy)
+
+        self.save_parameters_in_parameter_store(Platform.IOS)

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/transcribe_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/transcribe_stack.py
@@ -1,0 +1,27 @@
+from aws_cdk import aws_iam, core
+
+from common.common_stack import CommonStack
+from common.region_aware_stack import RegionAwareStack
+
+
+class TranscribeStack(RegionAwareStack):
+    def __init__(self, scope: core.Construct, id: str, common_stack: CommonStack, **kwargs) -> None:
+        super().__init__(scope, id, **kwargs)
+
+        self._supported_in_region = self.is_service_supported_in_region()
+
+        all_resources_policy = aws_iam.PolicyStatement(
+            effect=aws_iam.Effect.ALLOW,
+            actions=[
+                "transcribe:CreateVocabulary",
+                "transcribe:DeleteVocabulary",
+                "transcribe:GetTranscriptionJob",
+                "transcribe:GetVocabulary",
+                "transcribe:ListTranscriptionJobs",
+                "transcribe:ListVocabularies",
+                "transcribe:StartStreamTranscriptionWebSocket",
+                "transcribe:StartTranscriptionJob",
+            ],
+            resources=["*"],
+        )
+        common_stack.add_to_common_role_policies(self, policy_to_add=all_resources_policy)

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/transcribe_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/transcribe_stack.py
@@ -33,7 +33,9 @@ class TranscribeStack(RegionAwareStack):
 
     def create_bucket(self, common_stack):
         bucket_name = self.get_bucket_name("media")
-        bucket = aws_s3.Bucket(self, "integ_test_transcribe_bucket", bucket_name=bucket_name)
+        bucket = aws_s3.Bucket(
+            self, "integ_test_transcribe_bucket", bucket_name=bucket_name, removal_policy="DESTROY"
+        )
         self._parameters_to_save["bucket_name"] = bucket.bucket_name
         policy = aws_iam.PolicyStatement(
             effect=aws_iam.Effect.ALLOW,

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/transcribe_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/transcribe_stack.py
@@ -34,7 +34,10 @@ class TranscribeStack(RegionAwareStack):
     def create_bucket(self, common_stack):
         bucket_name = self.get_bucket_name("media")
         bucket = aws_s3.Bucket(
-            self, "integ_test_transcribe_bucket", bucket_name=bucket_name, removal_policy="DESTROY"
+            self,
+            "integ_test_transcribe_bucket",
+            bucket_name=bucket_name,
+            removal_policy=core.RemovalPolicy.DESTROY,
         )
         self._parameters_to_save["bucket_name"] = bucket.bucket_name
         policy = aws_iam.PolicyStatement(

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/transcribe_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/transcribe_stack.py
@@ -1,6 +1,7 @@
-from aws_cdk import aws_iam, core
+from aws_cdk import aws_iam, aws_s3, core
 
 from common.common_stack import CommonStack
+from common.platforms import Platform
 from common.region_aware_stack import RegionAwareStack
 
 
@@ -25,3 +26,12 @@ class TranscribeStack(RegionAwareStack):
             resources=["*"],
         )
         common_stack.add_to_common_role_policies(self, policy_to_add=all_resources_policy)
+
+        self.create_bucket()
+        
+        self.save_parameters_in_parameter_store(platform=Platform.IOS)
+
+    def create_bucket(self, common_stack):
+        bucket = aws_s3.Bucket(self, "integ_test_transcribe_bucket")
+        bucket.grant_read_write(common_stack.circleci_execution_role)
+        self._parameters_to_save["bucket_name"] = bucket.bucket_name

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/transcribe_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/transcribe_stack.py
@@ -27,8 +27,8 @@ class TranscribeStack(RegionAwareStack):
         )
         common_stack.add_to_common_role_policies(self, policy_to_add=all_resources_policy)
 
-        self.create_bucket()
-        
+        self.create_bucket(common_stack)
+
         self.save_parameters_in_parameter_store(platform=Platform.IOS)
 
     def create_bucket(self, common_stack):

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/transcribe_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/transcribe_stack.py
@@ -37,7 +37,7 @@ class TranscribeStack(RegionAwareStack):
         self._parameters_to_save["bucket_name"] = bucket.bucket_name
         policy = aws_iam.PolicyStatement(
             effect=aws_iam.Effect.ALLOW,
-            actions=["s3:GetObject"],
+            actions=["s3:DeleteObject", "s3:GetObject", "s3:PutObject"],
             resources=[f"arn:aws:s3:::{bucket_name}/*"],
         )
         common_stack.add_to_common_role_policies(self, policy_to_add=policy)

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/transcribe_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/transcribe_stack.py
@@ -32,6 +32,12 @@ class TranscribeStack(RegionAwareStack):
         self.save_parameters_in_parameter_store(platform=Platform.IOS)
 
     def create_bucket(self, common_stack):
-        bucket = aws_s3.Bucket(self, "integ_test_transcribe_bucket")
-        bucket.grant_read_write(common_stack.circleci_execution_role)
+        bucket_name = self.get_bucket_name("media")
+        bucket = aws_s3.Bucket(self, "integ_test_transcribe_bucket", bucket_name=bucket_name)
         self._parameters_to_save["bucket_name"] = bucket.bucket_name
+        policy = aws_iam.PolicyStatement(
+            effect=aws_iam.Effect.ALLOW,
+            actions=["s3:GetObject"],
+            resources=[f"arn:aws:s3:::{bucket_name}/*"],
+        )
+        common_stack.add_to_common_role_policies(self, policy_to_add=policy)

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/translate_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/translate_stack.py
@@ -1,0 +1,16 @@
+from aws_cdk import aws_iam, core
+
+from common.common_stack import CommonStack
+from common.region_aware_stack import RegionAwareStack
+
+
+class TranslateStack(RegionAwareStack):
+    def __init__(self, scope: core.Construct, id: str, common_stack: CommonStack, **kwargs) -> None:
+        super().__init__(scope, id, **kwargs)
+
+        self._supported_in_region = self.is_service_supported_in_region()
+
+        all_resources_policy = aws_iam.PolicyStatement(
+            effect=aws_iam.Effect.ALLOW, actions=["translate:TranslateText"], resources=["*"]
+        )
+        common_stack.add_to_common_role_policies(self, policy_to_add=all_resources_policy)


### PR DESCRIPTION
*Description of changes:*

Creating more iOS stacks, plus some refactoring/chore work.

Significant changes:
- **Breaking** Building the stack now requires the user to pass values for region and account ID on the command line context: `cdk deploy main -c region=us-west-2 -c account= 16*********5`
- New stacks throughout
- Retention policies on stacks now specify "DESTROY" -- previously several stacks were "RETAIN"ed
- Removed binary secret support
- Added StringList parameter support

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
