### PR TITLE
feat: Add developer-authenticated federated provider name

### DIFF
--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/mobileclient_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/mobileclient_stack.py
@@ -10,6 +10,9 @@ from common.secrets_manager import get_integ_tests_secrets
 
 
 class MobileClientStack(RegionAwareStack):
+    DEVELOPER_PROVIDER_NAME = "login.test.awsmobileclient"
+    """Used as the name of the developer-authenticated identity provider"""
+
     def __init__(self, scope: core.Construct, id: str, common_stack: CommonStack, **kwargs) -> None:
 
         super().__init__(scope, id, **kwargs)
@@ -65,6 +68,7 @@ class MobileClientStack(RegionAwareStack):
                     "providerName": f"cognito-idp.{self.region}.amazonaws.com/{default_user_pool.ref}",  # noqa: E501
                 }
             ],
+            developer_provider_name=MobileClientStack.DEVELOPER_PROVIDER_NAME,
         )
         self.update_parameters_for_identity_pool(identity_pool)
 
@@ -356,6 +360,7 @@ class MobileClientStack(RegionAwareStack):
     def update_parameters_for_identity_pool(self, identity_pool: aws_cognito.CfnIdentityPool):
         self._parameters_to_save.update(
             {
+                "developer_provider_name": MobileClientStack.DEVELOPER_PROVIDER_NAME,
                 "awsconfiguration/CredentialsProvider/CognitoIdentity/Default/PoolId": identity_pool.ref,  # noqa: E501
                 "awsconfiguration/CredentialsProvider/CognitoIdentity/Default/Region": self.region,
             }


### PR DESCRIPTION
This adds support for a `developer_provider_name` parameter, that will be consumed by https://github.com/aws-amplify/aws-sdk-ios/pull/2606

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
