### PR TITLE
fix: Remove hardcoded ios platform in role arn parameter

### DIFF
--- a/src/integ_test_resources/common/scripts/generate-test-config.sh
+++ b/src/integ_test_resources/common/scripts/generate-test-config.sh
@@ -253,7 +253,7 @@ function resolve_credentials {
     [[ $LOG_LEVEL -ge $LOG_LEVEL_TRACE ]] && set +x
 
     local circleci_execution_role_arn
-    circleci_execution_role_arn=$(aws ssm get-parameter --name '/mobile-sdk/ios/common/circleci_execution_role' | jq -r .Parameter.Value)
+    circleci_execution_role_arn=$(aws ssm get-parameter --name "/mobile-sdk/${platform}/common/circleci_execution_role" | jq -r .Parameter.Value)
     readonly circleci_execution_role_arn
 
     local assume_role_creds


### PR DESCRIPTION
Fixes the parameter name of the `circleci_execution_role_arn` where I inadvertently hardcoded "ios" instead of using the `platform` variable provided at runtime.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
