### PR TITLE
fix: additional policy actions for android sdk iot

### DIFF
--- a/src/integ_test_resources/android/sdk/integration/cdk/cdk_integration_tests_android/iot_stack.py
+++ b/src/integ_test_resources/android/sdk/integration/cdk/cdk_integration_tests_android/iot_stack.py
@@ -45,6 +45,9 @@ class IotStack(RegionAwareStack):
                     "iot:CreateKeysAndCertificate",
                     "iot:CreatePolicy",
                     "iot:AttachPolicy",
+                    "iot:DetachPolicy",
+                    "iot:UpdateCertificate",
+                    "iot:DeleteCertificate"
                 ],
                 resources=["*"],
             )


### PR DESCRIPTION
The Android test fail to run, with errors about not having access to
perform operations. Adding three additional policy allow statements
resolves it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
