### PR TITLE
fix: permit all iot permissions in android iot test

### DIFF
--- a/src/integ_test_resources/android/sdk/integration/cdk/cdk_integration_tests_android/iot_stack.py
+++ b/src/integ_test_resources/android/sdk/integration/cdk/cdk_integration_tests_android/iot_stack.py
@@ -36,18 +36,7 @@ class IotStack(RegionAwareStack):
                 effect=iam.Effect.ALLOW,
                 actions=[
                     "cognito-sync:*",
-                    "iot:Connect",
-                    "iot:Publish",
-                    "iot:Subscribe",
-                    "iot:Receive",
-                    "iot:GetThingShadow",
-                    "iot:DescribeEndpoint",
-                    "iot:CreateKeysAndCertificate",
-                    "iot:CreatePolicy",
-                    "iot:AttachPolicy",
-                    "iot:DetachPolicy",
-                    "iot:UpdateCertificate",
-                    "iot:DeleteCertificate"
+                    "iot:*"
                 ],
                 resources=["*"],
             )


### PR DESCRIPTION
The Android IoT tests arrange/create some resources. In order to delete
them, we need to include several more list/describe APIs. By the time
they are all added to the list, the IoT permissions list gets quite
long.

To ensure that the IoT stack is resilient to some changes in the client,
without needing to be continually updated/modified, we just move to
`IoT:*`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
