### PR TITLE
feat: android iot support for custom authorizers

### DIFF
--- a/src/integ_test_resources/android/sdk/integration/cdk/cdk_integration_tests_android/iot_stack.py
+++ b/src/integ_test_resources/android/sdk/integration/cdk/cdk_integration_tests_android/iot_stack.py
@@ -1,5 +1,6 @@
-from aws_cdk import aws_cognito as cognito
-from aws_cdk import aws_iam as iam
+from aws_cdk import aws_cognito
+from aws_cdk import aws_iam
+from aws_cdk import aws_lambda
 from aws_cdk import core
 
 from common.common_stack import CommonStack
@@ -8,19 +9,42 @@ from common.region_aware_stack import RegionAwareStack
 
 
 class IotStack(RegionAwareStack):
+    """
+    The iOS version of this stack works a little differently. It will
+    generate a custom authorizer in the CDK. The Android tests create
+    the custom authorizer _from the client._ Both the iOS and Android
+    CDK scripts *do* create a lambda function, though. The Android IoT
+    stack, here, will output the ARN of the lambda function so that it
+    may be referenced by the client, to complete resource construction.
+    """
+
     def __init__(self, scope: core.Construct, id: str, common_stack: CommonStack, **kwargs) -> None:
         super().__init__(scope, id, **kwargs)
 
         self._supported_in_region = self.is_service_supported_in_region()
 
-        identity_pool = cognito.CfnIdentityPool(
+        self._parameters_to_save = {}
+
+        self.setup_identity_pool()
+        self.setup_custom_authorizer()
+
+        self.save_parameters_in_parameter_store(platform=Platform.ANDROID)
+
+        stack_policy = aws_iam.PolicyStatement(
+            effect=aws_iam.Effect.ALLOW, actions=["cognito-identity:*", "iot:*"], resources=["*"]
+        )
+        common_stack.add_to_common_role_policies(self, policy_to_add=stack_policy)
+
+
+    def setup_identity_pool(self):
+        identity_pool = aws_cognito.CfnIdentityPool(
             self, "pinpoint_integ_test_android", allow_unauthenticated_identities=True
         )
 
-        unauthenticated_role = iam.Role(
+        unauthenticated_role = aws_iam.Role(
             self,
             "CognitoDefaultUnauthenticatedRole",
-            assumed_by=iam.FederatedPrincipal(
+            assumed_by=aws_iam.FederatedPrincipal(
                 "cognito-identity.amazonaws.com",
                 {
                     "StringEquals": {"cognito-identity.amazonaws.com:aud": identity_pool.ref},
@@ -32,8 +56,8 @@ class IotStack(RegionAwareStack):
             ),
         )
         unauthenticated_role.add_to_policy(
-            iam.PolicyStatement(
-                effect=iam.Effect.ALLOW,
+            aws_iam.PolicyStatement(
+                effect=aws_iam.Effect.ALLOW,
                 actions=[
                     "cognito-sync:*",
                     "iot:*"
@@ -41,18 +65,53 @@ class IotStack(RegionAwareStack):
                 resources=["*"],
             )
         )
-        cognito.CfnIdentityPoolRoleAttachment(
+        aws_cognito.CfnIdentityPoolRoleAttachment(
             self,
             "DefaultValid",
             identity_pool_id=identity_pool.ref,
             roles={"unauthenticated": unauthenticated_role.role_arn},
         )
 
-        self._parameters_to_save = {"identity_pool_id": identity_pool.ref}
-        self.save_parameters_in_parameter_store(platform=Platform.ANDROID)
+        self._parameters_to_save["identity_pool_id"] = identity_pool.ref
 
-        stack_policy = iam.PolicyStatement(
-            effect=iam.Effect.ALLOW, actions=["cognito-identity:*", "iot:*"], resources=["*"]
+
+    def setup_custom_authorizer(self):
+        # Note: "key" is a bit overloaded here. In the context of the custom authorizer, "key name"
+        # refers to the HTTP header field that the custom authorizer looks for a token value in.
+        #
+        # In the case of the custom authorizer key provider, the "key" is the KMS asymmetric CMK
+        # used to sign the token value passed in the `token_key_name` header. In order to keep the
+        # terminology consistent between client integ tests that are expecting to pass something for
+        # a "key name" field, we'll let the ambiguity stand.
+        token_key_name = "iot_custom_authorizer_token"
+        self._parameters_to_save["custom_authorizer_token_key_name"] = token_key_name
+
+        token_value = "allow"
+        self._parameters_to_save["custom_authorizer_token_value"] = token_value
+
+        authorizer_function_arn = self.setup_custom_authorizer_function()
+        self._parameters_to_save["custom_authorizer_lambda_arn"] = authorizer_function_arn
+
+
+    def setup_custom_authorizer_function(self) -> str:
+        """
+        Sets up the authorizer Lambda, and grants 'lambda:InvokeFunction' to the service principal
+        'iot.amazonaws.com'
+
+        :return: the ARN of the created function
+        """
+        authorizer_function = aws_lambda.Function(
+            self,
+            "iot_custom_authorizer_function",
+            runtime=aws_lambda.Runtime.PYTHON_3_7,
+            code=aws_lambda.Code.asset("custom_resources/iot_custom_authorizer_function"),
+            handler="iot_custom_authorizer.handler",
+            description="Sample custom authorizer that allows or denies based on 'token' value",
+            current_version_options=aws_lambda.VersionOptions(
+                removal_policy=core.RemovalPolicy.DESTROY
+            ),
+            environment={"RESOURCE_ARN": f"arn:aws:iot:{self.region}:{self.account}:*"},
         )
+        authorizer_function.grant_invoke(aws_iam.ServicePrincipal("iot.amazonaws.com"))
+        return authorizer_function.function_arn
 
-        common_stack.add_to_common_role_policies(self, policy_to_add=stack_policy)

--- a/src/integ_test_resources/android/sdk/integration/cdk/custom_resources/README.md
+++ b/src/integ_test_resources/android/sdk/integration/cdk/custom_resources/README.md
@@ -1,0 +1,11 @@
+The `iot_custom_authorizer_function` is duplicated from the iOS test
+resources.
+
+Unlike the iOS tests, the Android tests created the remaining custom
+resources from the client, itself.
+
+The value of the authorization lambda ARN is provided to the client via
+the configuration file, and the client builds the authorizer while
+arranging the tests.
+
+

--- a/src/integ_test_resources/android/sdk/integration/cdk/custom_resources/iot_custom_authorizer_function/iot_custom_authorizer.py
+++ b/src/integ_test_resources/android/sdk/integration/cdk/custom_resources/iot_custom_authorizer_function/iot_custom_authorizer.py
@@ -1,0 +1,35 @@
+import json
+import os
+
+
+def handler(event, __):
+    print(f"### handler: {event}")
+    token = event["token"].lower()
+    effect = "Allow" if token == "allow" else "Deny"
+    response = make_auth_response(effect)
+    response_string = json.dumps(response)
+    print(f"### returning response: {response_string}")
+    return response_string
+
+
+def make_auth_response(effect):
+    resource_arn = os.environ.get("RESOURCE_ARN", "*")
+    response = {
+        "isAuthenticated": True,
+        "principalId": "somePrincipalId",
+        "disconnectAfterInSeconds": 3600,
+        "refreshAfterInSeconds": 600,
+        "policyDocuments": [
+            {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Action": ["iot:Connect", "iot:Subscribe", "iot:Publish", "iot:Receive"],
+                        "Effect": effect,
+                        "Resource": resource_arn,
+                    }
+                ],
+            }
+        ],
+    }
+    return response


### PR DESCRIPTION
In the IoT stack for Android, adds a customer authorizer lambda function.

The lambda function, and details about how to interact with it, are added to the output variables provided to the Android client.

The Android client uses this information to construct a custom authorization before running tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
