### PR TITLE
fix(release_actions): Ensure more minor segments are reset on bump

### DIFF
--- a/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/helper/version/version.rb
+++ b/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/helper/version/version.rb
@@ -134,9 +134,15 @@ class Version
   # bump is used by the public methods to increment a specific segment of the normal
   # version. It expects to be called with 0, 1, or 2 relating to the major, minor, and
   # patch segments respectively. Prerelease and build metadata is not retained.
-  def bump(segment)
-    next_segments = segments.dup.tap do |segments|
-      segments[segment] += 1
+  def bump(part)
+    next_segments = segments.map.with_index do |segment, index|
+      if index == part
+        segment + 1
+      elsif index > part
+        0
+      else
+        segment
+      end
     end
 
     return new(next_segments)

--- a/src/fastlane/release_actions/spec/version/version_spec.rb
+++ b/src/fastlane/release_actions/spec/version/version_spec.rb
@@ -17,17 +17,29 @@ describe Version do
     context Version.new('1.0.0') do
       example { expect(subject.bump_major).to eq(Version.new('2.0.0')) }
     end
+
+    context Version.new('2.1.15') do
+      example { expect(subject.bump_major).to eq(Version.new('3.0.0')) }
+    end
   end
 
   describe '#bump_minor' do
     context Version.new('1.0.0') do
       example { expect(subject.bump_minor).to eq(Version.new('1.1.0')) }
     end
+
+    context Version.new('2.1.15') do
+      example { expect(subject.bump_minor).to eq(Version.new('2.2.0')) }
+    end
   end
 
   describe '#bump_patch' do
     context Version.new('1.0.0') do
       example { expect(subject.bump_patch).to eq(Version.new('1.0.1')) }
+    end
+
+    context Version.new('2.1.15') do
+      example { expect(subject.bump_patch).to eq(Version.new('2.1.16')) }
     end
   end
 


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* When bumping major, reset minor and patch to zero, and when bumping minor reset patch to zero.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
