### PR TITLE
fix(release_actions): Don't assume all commits have a scope

### DIFF
--- a/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/actions/build_changelog.rb
+++ b/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/actions/build_changelog.rb
@@ -19,26 +19,31 @@ module Fastlane
         if features.any?
           changelog.header(3) { 'Features' }
           changelog.unordered_list do
-            features.map { |feature| "#{bold(feature.scope)}: #{feature.subject}" }
+            features.map { |feature| display(feature) }
           end
         end
 
         if fixes.any?
           changelog.header(3) { 'Fixes' }
           changelog.unordered_list do
-            fixes.map { |fix| "#{bold(fix.scope)}: #{fix.subject}" }
+            fixes.map { |fix| display(fix) }
           end
         end
 
         if breaking_changes.any?
           changelog.header(3) { 'BREAKING CHANGES' }
-
-          changelog.unordered_list do
-            breaking_changes.map { |change| "#{bold(change.scope)}: #{change.breaking_change}" }
-          end
+          changelog.unordered_list { breaking_changes.map(&:breaking_change) }
         end
 
         changelog
+      end
+
+      def self.display(change)
+        if change.scope
+          "#{bold(change.scope)}: #{change.subject}"
+        else
+          change.subject
+        end
       end
 
       def self.description


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Previously the changelog output an empty scope and a colon for each commit based upon the assumption all commits would have a scope. This is false, so only output the subject if there's no scope.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
