### PR TITLE
Remove leading "v" character from version

### DIFF
--- a/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/helper/git.rb
+++ b/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/helper/git.rb
@@ -8,6 +8,11 @@ class Git
     last_tag = run(command, 'Could not find tag from HEAD')
 
     2.times { last_tag, = last_tag.rpartition('-') }
+
+    # Currently iOS prepends their release tags with a 'v'. Strip
+    # this prior to parsing the semantic version.
+    return last_tag[1..-1] if last_tag.start_with?('v')
+
     last_tag
   end
 

--- a/src/fastlane/release_actions/spec/git_spec.rb
+++ b/src/fastlane/release_actions/spec/git_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+require 'helper/git'
+
+describe Git do
+  describe '.last_version' do
+    example do
+      expect(Git).to receive(:run).and_return('1.0.2-13-gabcdef0123')
+      expect(Git.last_version).to eq('1.0.2')
+    end
+
+    context 'the tag is prepended with a "v"' do
+      it 'removes the "v"' do
+        expect(Git).to receive(:run).and_return('v1.0.2-13-gabcdef0123')
+        expect(Git.last_version).to eq('1.0.2')
+      end
+    end
+  end
+end


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Currently iOS prepends their release tags with a 'v' based upon an older
version of the Semantic Versioning specification. Remove this in the Git
helper before proceeding.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
