### PR TITLE
fix(release_actions): Add factory method to Version

### DIFF
--- a/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/actions/calculate_next_canary_version.rb
+++ b/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/actions/calculate_next_canary_version.rb
@@ -6,7 +6,7 @@ module Fastlane
   module Actions
     class CalculateNextCanaryVersionAction < Action
       def self.run(params)
-        version = Version.new(Git.last_version)
+        version = Version.from(Git.last_tag)
 
         if version.prerelease?
           version = version.bump_prerelease

--- a/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/actions/calculate_next_release_version.rb
+++ b/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/actions/calculate_next_release_version.rb
@@ -9,8 +9,9 @@ module Fastlane
   module Actions
     class CalculateNextReleaseVersionAction < Action
       def self.run(params)
-        version = Version.new(Git.last_version)
-        messages = Git.log(version)
+        tag = Git.last_tag
+        version = Version.from(tag)
+        messages = Git.log(tag)
         commits = Commits.from(messages)
 
         if commits.empty?

--- a/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/helper/git.rb
+++ b/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/helper/git.rb
@@ -3,17 +3,13 @@ require 'fastlane_core/ui/ui'
 class Git
   SEPARATOR = "=====END====="
 
-  def self.last_version
+  def self.last_tag
     command = %w(git describe --tag)
-    last_tag = run(command, 'Could not find tag from HEAD')
+    tag = run(command, 'Could not find tag from HEAD')
 
-    2.times { last_tag, = last_tag.rpartition('-') }
+    2.times { tag, = tag.rpartition('-') }
 
-    # Currently iOS prepends their release tags with a 'v'. Strip
-    # this prior to parsing the semantic version.
-    return last_tag[1..-1] if last_tag.start_with?('v')
-
-    last_tag
+    tag
   end
 
   def self.log(from, to = 'HEAD')

--- a/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/helper/version/version.rb
+++ b/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/helper/version/version.rb
@@ -11,6 +11,13 @@ class Version
 
   attr_reader :segments, :prerelease, :build
 
+  # iOS uses a convention where tags start with a 'v'. This will detect that and
+  # return the semantic version.
+  def self.from(tag)
+    return new(tag[1..-1]) if tag.start_with?('v')
+    new(tag)
+  end
+
   def initialize(version)
     # Acceptor ensures our input version is valid per the semver spec. See
     # `Version::Acceptor` for details.

--- a/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/version.rb
+++ b/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module ReleaseActions
-    VERSION = "1.0.0"
+    VERSION = "1.0.1"
   end
 end

--- a/src/fastlane/release_actions/spec/git_spec.rb
+++ b/src/fastlane/release_actions/spec/git_spec.rb
@@ -2,17 +2,15 @@ require 'spec_helper'
 require 'helper/git'
 
 describe Git do
-  describe '.last_version' do
+  describe '.last_tag' do
     example do
       expect(Git).to receive(:run).and_return('1.0.2-13-gabcdef0123')
-      expect(Git.last_version).to eq('1.0.2')
+      expect(Git.last_tag).to eq('1.0.2')
     end
 
-    context 'the tag is prepended with a "v"' do
-      it 'removes the "v"' do
-        expect(Git).to receive(:run).and_return('v1.0.2-13-gabcdef0123')
-        expect(Git.last_version).to eq('1.0.2')
-      end
+    examples do
+      expect(Git).to receive(:run).and_return('v12.53.110-13-gabcdef0123')
+      expect(Git.last_tag).to eq('v12.53.110')
     end
   end
 end

--- a/src/fastlane/release_actions/spec/version/version_spec.rb
+++ b/src/fastlane/release_actions/spec/version/version_spec.rb
@@ -6,6 +6,13 @@ describe Version do
     expect(Version.new('1.0.0').segments).to eq([1, 0, 0])
   end
 
+  describe '.from' do
+    example { expect(Version.from('1.0.0')).to eq(Version.new('1.0.0')) }
+    example { expect(Version.from('v1.0.0')).to eq(Version.new('1.0.0')) }
+    example { expect(Version.from('1.0.0-alpha.0')).to eq(Version.new('1.0.0-alpha.0')) }
+    example { expect(Version.from('v1.0.0-alpha.0')).to eq(Version.new('1.0.0-alpha.0')) }
+  end
+
   context 'with an invalid version string' do
     it 'raises an exception' do
       expect { Version.new('potatoes') }.to raise_error(ArgumentError)


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Add factory method to Version

Currently iOS uses a prefix "v" for their semantic version strings. In
our calculations we need to account for this so that we can retrieve the
right diff from the repo. Previously we stripped this in our Git helper,
but that was insufficient as we also need the original tag. This adds a
factory method to Version that wrangles a tag into a proper Version
object.

Co-authored-by: Ivan Artemiev <29709626+iartemiev@users.noreply.github.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
