### PR TITLE
fix(release_actions): Use list of tags to generate release version 

### DIFF
--- a/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/actions/calculate_next_release_version.rb
+++ b/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/actions/calculate_next_release_version.rb
@@ -9,7 +9,7 @@ module Fastlane
   module Actions
     class CalculateNextReleaseVersionAction < Action
       def self.run(params)
-        tag = Git.last_tag
+        tag = Git.last_release_tag
         version = Version.from(tag)
         messages = Git.log(tag)
         commits = Commits.from(messages)

--- a/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/helper/git.rb
+++ b/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/helper/git.rb
@@ -4,12 +4,17 @@ class Git
   SEPARATOR = "=====END====="
 
   def self.last_tag
-    command = %w(git describe --tag)
+    command = %w(git describe --tag --long)
     tag = run(command, 'Could not find tag from HEAD')
 
     2.times { tag, = tag.rpartition('-') }
 
     tag
+  end
+
+  def self.last_release_tag
+    command = 'git tag | sort -r | grep -v unstable | head -1'
+    run(command, 'Could not list tags').chomp
   end
 
   def self.log(from, to = 'HEAD')

--- a/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/version.rb
+++ b/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module ReleaseActions
-    VERSION = "1.0.2"
+    VERSION = "1.0.3"
   end
 end


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Use list of tags to generate release version

git describe will only return the most recent reachable tag. Instead,
use a list of all tags, sort them, filter out pre-release tags, and
return the latest.

Co-authored-by: Ivan Artemiev <29709626+iartemiev@users.noreply.github.com>


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
