### PR TITLE
fix(release_actions): enable set_key_value to work with .swift files

### DIFF
--- a/src/fastlane/release_actions/Gemfile.lock
+++ b/src/fastlane/release_actions/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-release_actions (1.0.1)
+    fastlane-plugin-release_actions (1.0.4)
 
 GEM
   remote: https://rubygems.org/

--- a/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/actions/set_key_value.rb
+++ b/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/actions/set_key_value.rb
@@ -1,25 +1,22 @@
+require_relative '../helper/key_value'
+
 module Fastlane
   module Actions
     class SetKeyValueAction < Action
       def self.run(params)
-        file = params[:file]
         key = params[:key]
+        file = params[:file]
         value = params[:value]
 
-        # Will match just the version that's contained inside of either single or double quotes
-        # E.g., if key = AMPLIFY_VERSION and the file contains: $AMPLIFY_VERSION = "1.3.3"
-        # it will match 1.3.3
-        regex_key = /(#{key}\s*=\s*["']\K)([\d\w.-]?)*/
-        file_contents = File.read(file)
+        key_value = KeyValue.new(key)
 
-        unless file_contents.match(regex_key)
-          UI.error("#{key} not present or doesn't have an explicit value in #{file}")
-          return
+        begin
+          key_value.match_and_replace_file(file: file, value: value)
+        rescue => exception
+          UI.error(exception)
+          raise exception
         end
 
-        file_contents = file_contents.gsub(regex_key, value)
-
-        File.open(file, "w") { |f| f.puts(file_contents) }
         UI.success("Successfully modified #{key} to value #{value} in #{file}")
       end
 

--- a/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/actions/set_key_value.rb
+++ b/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/actions/set_key_value.rb
@@ -6,7 +6,10 @@ module Fastlane
         key = params[:key]
         value = params[:value]
 
-        regex_key = /(?<=#{key})(\s*=\s*["'].*)/
+        # Will match just the version that's contained inside of either single or double quotes
+        # E.g., if key = AMPLIFY_VERSION and the file contains: $AMPLIFY_VERSION = "1.3.3"
+        # it will match 1.3.3
+        regex_key = /(?<=#{key}\s*=\s*["'])(.*?)(?=["'])/
         file_contents = File.read(file)
 
         unless file_contents.match(regex_key)
@@ -14,9 +17,7 @@ module Fastlane
           return
         end
 
-        new_value = " = '#{value}'"
-
-        file_contents = file_contents.gsub(regex_key, new_value)
+        file_contents = file_contents.gsub(regex_key, value)
 
         File.open(file, "w") { |f| f.puts(file_contents) }
         UI.success("Successfully modified #{key} to value #{value} in #{file}")

--- a/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/actions/set_key_value.rb
+++ b/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/actions/set_key_value.rb
@@ -9,7 +9,7 @@ module Fastlane
         # Will match just the version that's contained inside of either single or double quotes
         # E.g., if key = AMPLIFY_VERSION and the file contains: $AMPLIFY_VERSION = "1.3.3"
         # it will match 1.3.3
-        regex_key = /(?<=#{key}\s*=\s*["'])(.*?)(?=["'])/
+        regex_key = /(?<=#{key})(\s*=\s*["']\K)([\d\w.-]?)*/
         file_contents = File.read(file)
 
         unless file_contents.match(regex_key)

--- a/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/actions/set_key_value.rb
+++ b/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/actions/set_key_value.rb
@@ -9,7 +9,7 @@ module Fastlane
         # Will match just the version that's contained inside of either single or double quotes
         # E.g., if key = AMPLIFY_VERSION and the file contains: $AMPLIFY_VERSION = "1.3.3"
         # it will match 1.3.3
-        regex_key = /(?<=#{key})(\s*=\s*["']\K)([\d\w.-]?)*/
+        regex_key = /(#{key}\s*=\s*["']\K)([\d\w.-]?)*/
         file_contents = File.read(file)
 
         unless file_contents.match(regex_key)

--- a/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/helper/key_value.rb
+++ b/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/helper/key_value.rb
@@ -1,0 +1,27 @@
+class KeyValue
+  def initialize(key)
+    # Will match just the value that's contained inside of either single or double quotes
+    # E.g., if key = AMPLIFY_VERSION and the file contains: $AMPLIFY_VERSION = "1.3.3"
+    # it will match 1.3.3
+    @regex_key = /(#{key}\s*=\s*["']\K)([\d\w.-]?)*/
+  end
+
+  def match_and_replace_file(file:, value:)
+    file_contents = File.read(file)
+
+    unless match(file_contents)
+      raise StandardError, "#{key} not present or doesn't have an explicit value in #{file}"
+    end
+
+    file_contents = replace(file_contents: file_contents, value: value)
+    File.open(file, "w") { |f| f.puts(file_contents) }
+  end
+
+  def match(file_contents)
+    file_contents.match(@regex_key)
+  end
+
+  def replace(file_contents:, value:)
+    file_contents.gsub(@regex_key, value)
+  end
+end

--- a/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/version.rb
+++ b/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module ReleaseActions
-    VERSION = "1.0.3"
+    VERSION = "1.0.4"
   end
 end

--- a/src/fastlane/release_actions/spec/key_value_spec.rb
+++ b/src/fastlane/release_actions/spec/key_value_spec.rb
@@ -46,7 +46,7 @@ describe KeyValue do
       result = swift_key_value.match(SWIFT_CONTENT_PRE).to_s
       expect(result).to eq('1.0.4')
     end
-    
+
     example do
       result = wrong_key_value.match(SPEC_CONTENT_PRE).to_s
       expect(result).to eq('')
@@ -58,7 +58,7 @@ describe KeyValue do
       result = spec_key_value.replace(file_contents: SPEC_CONTENT_PRE, value: '2.0.0').to_s
       expect(result).to eq(SPEC_CONTENT_POST)
     end
-    
+
     example do
       result = swift_key_value.replace(file_contents: SWIFT_CONTENT_PRE, value: '2.0.0').to_s
       expect(result).to eq(SWIFT_CONTENT_POST)

--- a/src/fastlane/release_actions/spec/key_value_spec.rb
+++ b/src/fastlane/release_actions/spec/key_value_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+require 'helper/key_value'
+
+SPEC_CONTENT_PRE = <<~EOS
+  # Version definitions
+  $AMPLIFY_VERSION = '1.0.4'
+  $AMPLIFY_RELEASE_TAG = "v#{$AMPLIFY_VERSION}"
+EOS
+
+SPEC_CONTENT_POST = <<~EOS
+  # Version definitions
+  $AMPLIFY_VERSION = '2.0.0'
+  $AMPLIFY_RELEASE_TAG = "v#{$AMPLIFY_VERSION}"
+EOS
+
+SWIFT_CONTENT_PRE = <<~EOS
+  override public class func baseUserAgent() -> String! {
+    //TODO: Retrieve this version from a centralized location:
+    let version = "1.0.4"
+    let sdkName = "amplify-iOS"
+    return "\(sdkName)/\(version)"
+  }
+EOS
+
+SWIFT_CONTENT_POST = <<~EOS
+  override public class func baseUserAgent() -> String! {
+    //TODO: Retrieve this version from a centralized location:
+    let version = "2.0.0"
+    let sdkName = "amplify-iOS"
+    return "\(sdkName)/\(version)"
+  }
+EOS
+
+describe KeyValue do
+  let(:spec_key_value) { KeyValue.new('AMPLIFY_VERSION') }
+  let(:swift_key_value) { KeyValue.new('version') }
+  let(:wrong_key_value) { KeyValue.new('HOLY_GRAIL') }
+
+  describe '.match()' do
+    example do
+      result = spec_key_value.match(SPEC_CONTENT_PRE).to_s
+      expect(result).to eq('1.0.4')
+    end
+
+    example do
+      result = swift_key_value.match(SWIFT_CONTENT_PRE).to_s
+      expect(result).to eq('1.0.4')
+    end
+    
+    example do
+      result = wrong_key_value.match(SPEC_CONTENT_PRE).to_s
+      expect(result).to eq('')
+    end
+  end
+
+  describe '.replace()' do
+    example do
+      result = spec_key_value.replace(file_contents: SPEC_CONTENT_PRE, value: '2.0.0').to_s
+      expect(result).to eq(SPEC_CONTENT_POST)
+    end
+    
+    example do
+      result = swift_key_value.replace(file_contents: SWIFT_CONTENT_PRE, value: '2.0.0').to_s
+      expect(result).to eq(SWIFT_CONTENT_POST)
+    end
+  end
+end


### PR DESCRIPTION
We need to be able to increment values in .swift files, as well as in .rb.
E.g., here: https://github.com/aws-amplify/amplify-ios/blob/main/AmplifyPlugins/Core/AWSPluginsCore/ServiceConfiguration/AmplifyAWSServiceConfiguration.swift

Previously, this action would overwrite the value with single quotes `'` hardcoded. 
This PR updates the regex to ignore the quotes and just replace the value inside of them.


```ruby
$AMPLIFY_VERSION = '1.3.3'
# gets replaced with:
$AMPLIFY_VERSION = '1.3.4'
```

```swift
let version = "1.3.3"
// gets replaced with:
let version = "1.3.4"
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
