### PR TITLE
feat(IoT): Add (beta) resources for custom enhanced IoT Authorizer

### DIFF
--- a/src/integ_test_resources/common/constants.py
+++ b/src/integ_test_resources/common/constants.py
@@ -1,0 +1,7 @@
+
+class Constants:
+    custom_auth_user_pass_username = "aws-sdk-user?SDK=iOS&Version="
+    custom_auth_user_pass_password = "%%aws-sdk-password**"
+    custom_auth_user_pass_uuid = "iot_custom_authorizer_provider_lambda_20200507150213"
+    custom_auth_user_pass_default_authorizer_name = "iot_custom_authorizer_user_pass"
+    custom_auth_user_pass_domain_configuration_name = "aws_test_iot_custom_authorizer_user_pass"

--- a/src/integ_test_resources/common/constants.py
+++ b/src/integ_test_resources/common/constants.py
@@ -1,7 +1,0 @@
-
-class Constants:
-    custom_auth_user_pass_username = "aws-sdk-user?SDK=iOS&Version="
-    custom_auth_user_pass_password = "%%aws-sdk-password**"
-    custom_auth_user_pass_uuid = "iot_custom_authorizer_provider_lambda_20200507150213"
-    custom_auth_user_pass_default_authorizer_name = "iot_custom_authorizer_user_pass"
-    custom_auth_user_pass_domain_configuration_name = "aws_test_iot_custom_authorizer_user_pass"

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/iot_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/iot_stack.py
@@ -6,7 +6,7 @@ from aws_cdk import aws_iam, aws_iot, aws_lambda, core, custom_resources
 from common.common_stack import CommonStack
 from common.platforms import Platform
 from common.region_aware_stack import RegionAwareStack
-
+from common.constants import Constants
 
 class IotStack(RegionAwareStack):
     def __init__(self, scope: core.Construct, id: str, common_stack: CommonStack, **kwargs) -> None:
@@ -21,6 +21,8 @@ class IotStack(RegionAwareStack):
         # Set up custom resources
         self.setup_iot_endpoint_provider()
         self.setup_custom_authorizer()
+
+        self.setup_custom_authorizer_user_pass()
 
         self.save_parameters_in_parameter_store(platform=Platform.IOS)
 
@@ -156,7 +158,11 @@ class IotStack(RegionAwareStack):
         token_value = "allow"
         self._parameters_to_save["custom_authorizer_token_value"] = token_value
 
-        iot_custom_authorizer_key_resource = self.create_custom_authorizer_signing_key(token_value)
+        iot_custom_authorizer_key_resource = self.create_custom_authorizer_signing_key_generic(
+            "1",
+            "Manages an asymmetric CMK and token signature for iot custom authorizer.",
+            token_value,
+        )
 
         custom_authorizer_token_signature = iot_custom_authorizer_key_resource.get_att(
             "custom_authorizer_token_signature"
@@ -165,15 +171,24 @@ class IotStack(RegionAwareStack):
             "custom_authorizer_token_signature"
         ] = custom_authorizer_token_signature
 
-        authorizer_function_arn = self.setup_custom_authorizer_function()
+        authorizer_function_arn = self.setup_custom_authorizer_function(
+            "1",
+            "custom_resources/iot_custom_authorizer_function",
+            "iot_custom_authorizer.handler",
+            "Sample custom authorizer that allows or denies based on 'token' value",
+            {},
+            self.region,
+        )
 
         create_authorizer_policy = aws_iam.PolicyStatement(
-            effect=aws_iam.Effect.ALLOW, actions=["iot:CreateAuthorizer"], resources=["*"],
+            effect=aws_iam.Effect.ALLOW,
+            actions=["iot:CreateAuthorizer", "iot:UpdateAuthorizer", "iot:DeleteAuthorizer"],
+            resources=["*"],
         )
         provider_lambda = aws_lambda.SingletonFunction(
             self,
             "iot_custom_authorizer_provider_lambda",
-            uuid="iot_custom_authorizer_provider_lambda_20200507150213",
+            uuid=Constants.custom_auth_user_pass_uuid,
             runtime=aws_lambda.Runtime.PYTHON_3_7,
             code=aws_lambda.Code.asset("custom_resources/iot_custom_authorizer_provider"),
             handler="iot_custom_authorizer_provider.on_event",
@@ -205,29 +220,126 @@ class IotStack(RegionAwareStack):
             },
         )
 
-    def setup_custom_authorizer_function(self) -> str:
+    def setup_custom_authorizer_user_pass(self):
+        custom_authorizer_name = Constants.custom_auth_user_pass_default_authorizer_name
+        self._parameters_to_save["custom_authorizer_user_pass_name"] = custom_authorizer_name
+        token_key_name = "IoTTokenKeyName"
+        self._parameters_to_save["custom_authorizer_user_pass_token_key_name"] = token_key_name
+        token_value = "allow"
+        self._parameters_to_save["custom_authorizer_user_pass_token_value"] = token_value
+        self._parameters_to_save["custom_authorizer_user_pass_username"] = Constants.custom_auth_user_pass_username
+        self._parameters_to_save["custom_authorizer_user_pass_password"] = Constants.custom_auth_user_pass_password
+
+        iot_custom_authorizer_key_resource = self.create_custom_authorizer_signing_key_generic(
+            "2",
+            "Manages an asymmetric CMK and token signature for iot custom authorizer with username and password.",
+            token_value,
+        )
+
+        custom_authorizer_token_signature = iot_custom_authorizer_key_resource.get_att(
+            "custom_authorizer_token_signature"
+        ).to_string()
+        self._parameters_to_save[
+            "custom_authorizer_user_pass_token_signature"
+        ] = custom_authorizer_token_signature
+
+        # Force region to 'us-east-1' due to enhanced custom authorizers only available in this region
+        authorizer_function_arn = self.setup_custom_authorizer_function(
+            "2",
+            "custom_resources/iot_custom_authorizer_user_pass_function",
+            "iot_custom_authorizer_user_pass.handler",
+            "Sample custom authorizer that allows or denies based on username and password",
+            {"custom_auth_user_pass_username": Constants.custom_auth_user_pass_username,
+             "custom_auth_user_pass_password": Constants.custom_auth_user_pass_password},
+            "us-east-1",
+        )
+        create_authorizer_policy = aws_iam.PolicyStatement(
+            effect=aws_iam.Effect.ALLOW,
+            actions=[
+                "iot:CreateAuthorizer",
+                "iot:UpdateAuthorizer",
+                "iot:DeleteAuthorizer",
+                "iot:UpdateDomainConfiguration",
+                "iot:CreateDomainConfiguration",
+                "iot:DescribeDomainConfiguration",
+                "iot:DeleteDomainConfiguration",
+            ],
+            resources=["*"],
+        )
+        provider_lambda = aws_lambda.SingletonFunction(
+            self,
+            "iot_custom_authorizer_user_pass_provider_lambda",
+            uuid="iot_custom_authorizer_user_pass_provider_lambda_20200727123737",
+            runtime=aws_lambda.Runtime.PYTHON_3_7,
+            code=aws_lambda.Code.asset("custom_resources/iot_custom_authorizer_user_pass_provider"),
+            handler="iot_custom_authorizer_user_pass_provider.on_event",
+            description="Sets up an IoT custom authorizer for user password & required domain config due to beta status",
+            environment={"custom_auth_user_pass_uuid" : Constants.custom_auth_user_pass_uuid,
+                         "custom_auth_user_pass_default_authorizer_name" : Constants.custom_auth_user_pass_default_authorizer_name,
+                         "custom_auth_user_pass_domain_configuration_name" : Constants.custom_auth_user_pass_domain_configuration_name},
+            current_version_options=aws_lambda.VersionOptions(
+                removal_policy=core.RemovalPolicy.DESTROY
+            ),
+            initial_policy=[create_authorizer_policy],
+        )
+
+        provider = custom_resources.Provider(
+            self, "iot_custom_authorizer_user_pass_provider", on_event_handler=provider_lambda
+        )
+
+        public_key = iot_custom_authorizer_key_resource.get_att(
+            "custom_authorizer_public_key"
+        ).to_string()
+
+        iot_endpoint = core.CustomResource(
+            self,
+            "iot_custom_authorizer_user_pass",
+            resource_type="Custom::IoTCustomAuthorizer",
+            service_token=provider.service_token,
+            properties={
+                "authorizer_function_arn": authorizer_function_arn,
+                "authorizer_name": custom_authorizer_name,
+                "public_key": public_key,
+                "token_key_name": token_key_name,
+            },
+        )
+        endpoint_address = iot_endpoint.get_att("BetaEndpointAddress").to_string()
+        self._parameters_to_save["iot_beta_endpoint_address"] = endpoint_address
+
+    def merge_dict(self, dict1, dict2):
+        res = {**dict1, **dict2}
+        return res
+
+    def setup_custom_authorizer_function(
+        self, unique_id, code_asset, code_handler, description, environment, region
+    ) -> str:
         """
         Sets up the authorizer Lambda, and grants 'lambda:InvokeFunction' to the service principal
         'iot.amazonaws.com'
 
         :return: the ARN of the created function
         """
+        common_vars={"RESOURCE_ARN": f"arn:aws:iot:{region}:{self.account}:*"}
+        merged_environment_vars = self.merge_dict(common_vars, environment)
         authorizer_function = aws_lambda.Function(
             self,
-            "iot_custom_authorizer_function",
+            f"iot_custom_authorizer_function_{unique_id}",
             runtime=aws_lambda.Runtime.PYTHON_3_7,
-            code=aws_lambda.Code.asset("custom_resources/iot_custom_authorizer_function"),
-            handler="iot_custom_authorizer.handler",
-            description="Sample custom authorizer that allows or denies based on 'token' value",
+            code=aws_lambda.Code.asset(code_asset),
+            handler=code_handler,
+            description=description,
             current_version_options=aws_lambda.VersionOptions(
                 removal_policy=core.RemovalPolicy.DESTROY
             ),
-            environment={"RESOURCE_ARN": f"arn:aws:iot:{self.region}:{self.account}:*"},
+            environment=merged_environment_vars
         )
+
         authorizer_function.grant_invoke(aws_iam.ServicePrincipal("iot.amazonaws.com"))
         return authorizer_function.function_arn
 
-    def create_custom_authorizer_signing_key(self, token_value) -> core.CustomResource:
+    def create_custom_authorizer_signing_key_generic(
+        self, unique_id, description, token_value
+    ) -> core.CustomResource:
         """
         Uses a Lambda to create an asymmetric key pair, since neither CFn nor CDK support that as of
         this writing (2020-05-09)
@@ -245,12 +357,12 @@ class IotStack(RegionAwareStack):
         )
         provider_lambda = aws_lambda.SingletonFunction(
             self,
-            "iot_custom_authorizer_key_provider_lambda",
-            uuid="iot_custom_authorizer_key_provider_lambda_20200507150213",
+            f"iot_custom_authorizer_key_provider_lambda_{unique_id}",
+            uuid=f"iot_custom_authorizer_key_provider_lambda_20200507150213_{unique_id}",
             runtime=aws_lambda.Runtime.PYTHON_3_7,
             code=aws_lambda.Code.asset("custom_resources/iot_custom_authorizer_key_provider"),
             handler="iot_custom_authorizer_key_provider.on_event",
-            description="Manages an asymmetric CMK and token signature for iot custom authorizer.",
+            description=description,
             current_version_options=aws_lambda.VersionOptions(
                 removal_policy=core.RemovalPolicy.DESTROY
             ),
@@ -258,12 +370,14 @@ class IotStack(RegionAwareStack):
         )
 
         provider = custom_resources.Provider(
-            self, "iot_custom_authorizer_key_provider", on_event_handler=provider_lambda
+            self,
+            f"iot_custom_authorizer_key_provider_{unique_id}",
+            on_event_handler=provider_lambda,
         )
 
         iot_custom_authorizer_key = core.CustomResource(
             self,
-            "iot_custom_authorizer_key",
+            f"iot_custom_authorizer_key_{unique_id}",
             resource_type="Custom::IoTCustomAuthorizer",
             service_token=provider.service_token,
             properties={"token_value": token_value},

--- a/src/integ_test_resources/ios/sdk/integration/cdk/custom_resources/iot_custom_authorizer_user_pass_function/iot_custom_authorizer_user_pass.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/custom_resources/iot_custom_authorizer_user_pass_function/iot_custom_authorizer_user_pass.py
@@ -1,0 +1,45 @@
+import json
+import base64
+import os
+
+def handler(event, __):
+    print(f"### handler: {event}")
+    token = event["token"].lower()
+
+    mqtt_user = event["protocolData"]["mqtt"]["username"]
+    ios_token = os.environ["custom_auth_user_pass_username"]
+
+    expected_password = os.environ["custom_auth_user_pass_password"]
+    password = event["protocolData"]["mqtt"]["password"]
+    base64_decoded = base64.b64decode(password).decode("utf-8")
+    passwordMatches = expected_password == base64_decoded
+
+    effect = "Allow" if token == "allow" and mqtt_user.startswith(ios_token) and passwordMatches else "Deny"
+
+    response = make_auth_response(effect)
+    response_string = json.dumps(response)
+    print(f"### returning response: {response_string}")
+    return response_string
+
+
+def make_auth_response(effect):
+    resource_arn = os.environ.get("RESOURCE_ARN", "*")
+    response = {
+        "isAuthenticated": True,
+        "principalId": "somePrincipalId",
+        "disconnectAfterInSeconds": 3600,
+        "refreshAfterInSeconds": 600,
+        "policyDocuments": [
+            {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Action": ["iot:Connect", "iot:Subscribe", "iot:Publish", "iot:Receive"],
+                        "Effect": effect,
+                        "Resource": resource_arn,
+                    }
+                ],
+            }
+        ],
+    }
+    return response

--- a/src/integ_test_resources/ios/sdk/integration/cdk/custom_resources/iot_custom_authorizer_user_pass_function/iot_custom_authorizer_user_pass.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/custom_resources/iot_custom_authorizer_user_pass_function/iot_custom_authorizer_user_pass.py
@@ -7,14 +7,14 @@ def handler(event, __):
     token = event["token"].lower()
 
     mqtt_user = event["protocolData"]["mqtt"]["username"]
-    ios_token = os.environ["custom_auth_user_pass_username"]
+    expected_username = os.environ["custom_auth_user_pass_username"]
 
     expected_password = os.environ["custom_auth_user_pass_password"]
     password = event["protocolData"]["mqtt"]["password"]
     base64_decoded = base64.b64decode(password).decode("utf-8")
     passwordMatches = expected_password == base64_decoded
 
-    effect = "Allow" if token == "allow" and mqtt_user.startswith(ios_token) and passwordMatches else "Deny"
+    effect = "Allow" if token == "allow" and mqtt_user.startswith(expected_username) and passwordMatches else "Deny"
 
     response = make_auth_response(effect)
     response_string = json.dumps(response)

--- a/src/integ_test_resources/ios/sdk/integration/cdk/custom_resources/iot_custom_authorizer_user_pass_provider/README.md
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/custom_resources/iot_custom_authorizer_user_pass_provider/README.md
@@ -1,0 +1,13 @@
+## IoT Custom Enhanced Authorizer
+
+This is a custom resource to test IoT custom authorizers in the SDK.
+
+IoT Custom Authorizers use a Lambda to provide an authorization decision and a policy statement for an incoming IoT request.
+
+IoT clients provide an authorization token in the specified HTTP header field, and a signature of that token.
+
+The IoT gateway validates the signature with the public key used to create the custom authorizer, and invokes the authorizer if the signature is valid.
+
+In this stack, the authorizer is created using an asymmetric key created in KMS. The custom authorizer provider uses the public key provided by the `iot_custom_authorizer_key_provider` (see that README for details).
+
+Finally, we use create & update domain configuration to get an endpoint to achieve the enhanced payload in our lambda.  Note that this is only while this feature is in beta, and should not be required at a later point in time.

--- a/src/integ_test_resources/ios/sdk/integration/cdk/custom_resources/iot_custom_authorizer_user_pass_provider/README.md
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/custom_resources/iot_custom_authorizer_user_pass_provider/README.md
@@ -10,4 +10,8 @@ The IoT gateway validates the signature with the public key used to create the c
 
 In this stack, the authorizer is created using an asymmetric key created in KMS. The custom authorizer provider uses the public key provided by the `iot_custom_authorizer_key_provider` (see that README for details).
 
-Finally, we use create & update domain configuration to get an endpoint to achieve the enhanced payload in our lambda.  Note that this is only while this feature is in beta, and should not be required at a later point in time.
+Finally, we use create & update domain configuration to get an endpoint to achieve the enhanced payload in our lambda.
+
+Notes on beta:
+ * Updating the domain configuration is an artifact of this feature being in beta, and should not be required at a later point in time.
+ * The enhanced authorizer behavior is only available in the region "us-east-1" while this feature is under a beta release.

--- a/src/integ_test_resources/ios/sdk/integration/cdk/custom_resources/iot_custom_authorizer_user_pass_provider/iot_custom_authorizer_user_pass_provider.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/custom_resources/iot_custom_authorizer_user_pass_provider/iot_custom_authorizer_user_pass_provider.py
@@ -100,7 +100,7 @@ def delete_authorizer(name):
     client = boto3.client("iot")
     domain_configuration_name = os.environ["custom_auth_user_pass_domain_configuration_name"]
 
-    update_domain_configuration_response = client.update_domain_configuration(
+    client.update_domain_configuration(
         domainConfigurationName=domain_configuration_name, domainConfigurationStatus="DISABLED"
     )
     # It would be nice to clean this stuff up, but this will always fail because you will get an error of:

--- a/src/integ_test_resources/ios/sdk/integration/cdk/custom_resources/iot_custom_authorizer_user_pass_provider/iot_custom_authorizer_user_pass_provider.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/custom_resources/iot_custom_authorizer_user_pass_provider/iot_custom_authorizer_user_pass_provider.py
@@ -1,0 +1,114 @@
+import boto3
+import os
+# Note: Make this dynamic if there is more than one custom authorizer in the stack
+
+def on_event(event, __):
+    print(f"### on_event({event})")
+    request_type = event["RequestType"]
+    if request_type == "Create":
+        return on_create_or_update(event)
+    if request_type == "Update":
+        return on_create_or_update(event)
+    if request_type == "Delete":
+        return on_delete(event)
+    raise Exception("Invalid request type: %s" % request_type)
+
+
+def on_create_or_update(event):
+    print(f"### on_create_or_update({event})")
+    physical_id = os.environ["custom_auth_user_pass_uuid"]
+    custom_authorizer_function_arn = event["ResourceProperties"]["authorizer_function_arn"]
+    custom_authorizer_name = event["ResourceProperties"]["authorizer_name"]
+    public_key = event["ResourceProperties"]["public_key"]
+    token_key_name = event["ResourceProperties"]["token_key_name"]
+    create_authorizer(
+        custom_authorizer_name, custom_authorizer_function_arn, public_key, token_key_name
+    )
+
+    # Creating a domain config is required for enhanced user auth
+    beta_endpoint_addr = create_or_update_domainConfig()
+    response = {
+        "PhysicalResourceId": physical_id,
+        "Data": {"BetaEndpointAddress": beta_endpoint_addr},
+    }
+    print(f"### on_create_or_update response: {response}")
+    return response
+
+
+def create_or_update_domainConfig():
+    client = boto3.client("iot")
+    default_authorizer_name = os.environ["custom_auth_user_pass_default_authorizer_name"]
+    domain_configuration_name = os.environ["custom_auth_user_pass_domain_configuration_name"]
+
+    try:
+        create_domain_configuration_response = client.create_domain_configuration(
+            domainConfigurationName=domain_configuration_name
+        )
+        print(f"### create_domain_configuration response: {create_domain_configuration_response}")
+    except client.exceptions.ResourceAlreadyExistsException as e:
+        print("Already defined, continuing")
+
+    update_domain_configuration_response = client.update_domain_configuration(
+        domainConfigurationName=domain_configuration_name,
+        domainConfigurationStatus="ENABLED",
+        authorizerConfig={"defaultAuthorizerName": default_authorizer_name},
+    )
+    print(f"### update_domain_configuration response: {update_domain_configuration_response}")
+
+    describe_domain_configuration_response = client.describe_domain_configuration(
+        domainConfigurationName=domain_configuration_name
+    )
+    print(f"### describe_domain_configuration response: {describe_domain_configuration_response}")
+
+    beta_endpoint_addr = describe_domain_configuration_response["domainName"]
+    print(f"### beta_endpoint_addr: {beta_endpoint_addr}")
+
+    return beta_endpoint_addr
+
+
+def on_delete(event):
+    print(f"### on_delete({event})")
+    physical_id = os.environ["custom_auth_user_pass_uuid"]
+    custom_authorizer_name = event["ResourceProperties"]["authorizer_name"]
+    delete_authorizer(custom_authorizer_name)
+    response = {"PhysicalResourceId": physical_id}
+    print(f"### on_delete response: {response}")
+    return response
+
+
+def create_authorizer(name, function_arn, public_key, token_key_name):
+    print(f"### create_authorizer({name, function_arn, public_key, token_key_name})")
+    client = boto3.client("iot")
+    formatted_key = format_public_key(public_key)
+    create_authorizer_response = client.create_authorizer(
+        authorizerName=name,
+        authorizerFunctionArn=function_arn,
+        tokenKeyName=token_key_name,
+        status="ACTIVE",
+        signingDisabled=False,
+        tokenSigningPublicKeys={"public_key": formatted_key},
+    )
+    print(f"### create_authorizer_response: {create_authorizer_response}")
+
+
+def format_public_key(public_key):
+    return f"-----BEGIN PUBLIC KEY-----\n{public_key}\n-----END PUBLIC KEY-----"
+
+
+def delete_authorizer(name):
+    print(f"### delete_authorizer({name})")
+    client = boto3.client("iot")
+    domain_configuration_name = os.environ["custom_auth_user_pass_domain_configuration_name"]
+
+    update_domain_configuration_response = client.update_domain_configuration(
+        domainConfigurationName=domain_configuration_name, domainConfigurationStatus="DISABLED"
+    )
+    # It would be nice to clean this stuff up, but this will always fail because you will get an error of:
+    # Failed to delete resource. Error: An error occurred (InvalidRequestException) when calling the DeleteDomainConfiguration operation: AWS Managed Domain Configuration must be disabled for at least 7 days before it can be deleted
+    # delete_domain_configuration_response = client.delete_domain_configuration(domainConfigurationName="aws_test_iot_custom_authorizer_user_pass")
+
+    update_authorizer_response = client.update_authorizer(authorizerName=name, status="INACTIVE")
+    print(f"### update_authorizer_response: {update_authorizer_response}")
+
+    delete_authorizer_response = client.delete_authorizer(authorizerName=name)
+    print(f"### delete_authorizer_response: {delete_authorizer_response}")


### PR DESCRIPTION
Adding resources for enhanced IoT custom authorizer.  Resources for this authorizer must be:
* In us-east-1
* Must call updateDomainConfiguration w/ specific arguments to get back a "beta" endpoint.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
