### PR TITLE
fix(release_actions): add configuration options in support of Flutter

### DIFF
--- a/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/actions/calculate_next_canary_version.rb
+++ b/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/actions/calculate_next_canary_version.rb
@@ -34,11 +34,11 @@ module Fastlane
         [
           FastlaneCore::ConfigItem.new(
             key: :prerelease_identifier,
-            env_name: "PRERELEASE_IDENTIFIER",
-            description: "The pre-release identifier (e.g. unstable, dev, preview) for prerelease versions",
+            env_name: 'PRERELEASE_IDENTIFIER',
+            description: 'The pre-release identifier (e.g. unstable, dev, preview) for prerelease versions',
             type: String,
             optional: true,
-            default_value: "unstable"
+            default_value: 'unstable'
           )
         ]
       end

--- a/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/actions/calculate_next_canary_version.rb
+++ b/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/actions/calculate_next_canary_version.rb
@@ -12,7 +12,7 @@ module Fastlane
           version = version.bump_prerelease
         else
           version = version.bump_patch
-          version = version.as_prerelease('unstable')
+          version = version.as_prerelease(params[:prerelease_tag])
         end
 
         version.to_s
@@ -31,7 +31,16 @@ module Fastlane
       end
 
       def self.available_options
-        []
+        [
+          FastlaneCore::ConfigItem.new(
+            key: :prerelease_identifer,
+            env_name: "PRERELEASE_IDENTIFIER",
+            description: "The pre-release identifier (e.g. unstable, dev, preview) for prerelease versions",
+            type: String,
+            optional: true,
+            default_value: "unstable"
+          )
+        ]
       end
 
       def self.is_supported?(platform)

--- a/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/actions/calculate_next_canary_version.rb
+++ b/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/actions/calculate_next_canary_version.rb
@@ -12,7 +12,7 @@ module Fastlane
           version = version.bump_prerelease
         else
           version = version.bump_patch
-          version = version.as_prerelease(params[:prerelease_tag])
+          version = version.as_prerelease(params[:prerelease_identifier])
         end
 
         version.to_s
@@ -33,7 +33,7 @@ module Fastlane
       def self.available_options
         [
           FastlaneCore::ConfigItem.new(
-            key: :prerelease_identifer,
+            key: :prerelease_identifier,
             env_name: "PRERELEASE_IDENTIFIER",
             description: "The pre-release identifier (e.g. unstable, dev, preview) for prerelease versions",
             type: String,

--- a/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/helper/commit/commits.rb
+++ b/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/helper/commit/commits.rb
@@ -1,6 +1,8 @@
 class Commits
   include Enumerable
 
+  attr_reader :commits
+
   def self.from(messages)
     commits = messages.map { |message| Commit::Parser.new(message).parse }
 
@@ -37,7 +39,4 @@ class Commits
     commits.empty?
   end
 
-  private
-
-  attr_reader :commits
 end

--- a/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/helper/git.rb
+++ b/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/helper/git.rb
@@ -15,7 +15,7 @@ class Git
   def self.last_release_tag
     command = %w(git tag)
     tags = run(command, 'Could not list tags').chomp.gsub(/\s+/m, ' ').strip.split
-    release_tags = tags.select{ |tag| !Version.from(tag).prerelease? }
+    release_tags = tags.reject { |tag| Version.from(tag).prerelease? }
     release_tags.max_by { |tag| Version.from(tag) }
   end
 

--- a/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/helper/git.rb
+++ b/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/helper/git.rb
@@ -13,7 +13,8 @@ class Git
   end
 
   def self.last_release_tag
-    command = 'git tag | sort -r | grep -v unstable | head -1'
+    # the hyphen should only occur in pre-release tags
+    command = 'git tag | sort -r | grep -v \'-\' | head -1'
     run(command, 'Could not list tags').chomp
   end
 

--- a/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/helper/git.rb
+++ b/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/helper/git.rb
@@ -14,7 +14,6 @@ class Git
   end
 
   def self.last_release_tag
-    # the hyphen should only occur in pre-release tags
     command = "git tag | sort -r | egrep '#{RELEASE_REGEX}' | head -1"
     run(command, 'Could not list tags').chomp
   end

--- a/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/helper/git.rb
+++ b/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/helper/git.rb
@@ -2,6 +2,7 @@ require 'fastlane_core/ui/ui'
 
 class Git
   SEPARATOR = "=====END====="
+  RELEASE_REGEX = '(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$'
 
   def self.last_tag
     command = %w(git describe --tag --long)
@@ -14,7 +15,7 @@ class Git
 
   def self.last_release_tag
     # the hyphen should only occur in pre-release tags
-    command = 'git tag | sort -r | grep -v \'-\' | head -1'
+    command = "git tag | sort -r | grep -e '#{RERELEASE_REGEX}' | head -1"
     run(command, 'Could not list tags').chomp
   end
 

--- a/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/helper/git.rb
+++ b/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/helper/git.rb
@@ -15,7 +15,7 @@ class Git
 
   def self.last_release_tag
     # the hyphen should only occur in pre-release tags
-    command = "git tag | sort -r | grep -e '#{RELEASE_REGEX}' | head -1"
+    command = "git tag | sort -r | egrep '#{RELEASE_REGEX}' | head -1"
     run(command, 'Could not list tags').chomp
   end
 

--- a/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/helper/git.rb
+++ b/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/helper/git.rb
@@ -2,7 +2,6 @@ require 'fastlane_core/ui/ui'
 
 class Git
   SEPARATOR = "=====END====="
-  RELEASE_REGEX = '(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$'
 
   def self.last_tag
     command = %w(git describe --tag --long)
@@ -14,8 +13,10 @@ class Git
   end
 
   def self.last_release_tag
-    command = "git tag | sort -r | egrep '#{RELEASE_REGEX}' | head -1"
-    run(command, 'Could not list tags').chomp
+    command = %w(git tag)
+    tags = run(command, 'Could not list tags').chomp.gsub(/\s+/m, ' ').strip.split
+    release_tags = tags.select{ |tag| !Version.from(tag).prerelease? }
+    release_tags.max_by { |tag| Version.from(tag) }
   end
 
   def self.log(from, to = 'HEAD')

--- a/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/helper/git.rb
+++ b/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/helper/git.rb
@@ -15,7 +15,7 @@ class Git
 
   def self.last_release_tag
     # the hyphen should only occur in pre-release tags
-    command = "git tag | sort -r | grep -e '#{RERELEASE_REGEX}' | head -1"
+    command = "git tag | sort -r | grep -e '#{RELEASE_REGEX}' | head -1"
     run(command, 'Could not list tags').chomp
   end
 

--- a/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/helper/key_value.rb
+++ b/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/helper/key_value.rb
@@ -3,6 +3,7 @@ class KeyValue
     # Will match just the value that's contained inside of either single or double quotes
     # E.g., if key = AMPLIFY_VERSION and the file contains: $AMPLIFY_VERSION = "1.3.3"
     # it will match 1.3.3
+    @key = key
     @regex_key = /(#{key}\s*[=:]\s*["']?\K)(\^?[\d\w.-]?)*/
   end
 
@@ -10,7 +11,7 @@ class KeyValue
     file_contents = File.read(file)
 
     unless match(file_contents)
-      raise StandardError, "#{key} not present or doesn't have an explicit value in #{file}"
+      raise StandardError, "#{@key} not present or doesn't have an explicit value in #{file}"
     end
 
     file_contents = replace(file_contents: file_contents, value: value)

--- a/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/helper/key_value.rb
+++ b/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/helper/key_value.rb
@@ -3,7 +3,7 @@ class KeyValue
     # Will match just the value that's contained inside of either single or double quotes
     # E.g., if key = AMPLIFY_VERSION and the file contains: $AMPLIFY_VERSION = "1.3.3"
     # it will match 1.3.3
-    @regex_key = /(#{key}\s*[=:]\s*["']?\K)([\d\w.-]?)*/
+    @regex_key = /(#{key}\s*[=:]\s*["']?\K)(\^?[\d\w.-]?)*/
   end
 
   def match_and_replace_file(file:, value:)

--- a/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/helper/key_value.rb
+++ b/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/helper/key_value.rb
@@ -3,7 +3,7 @@ class KeyValue
     # Will match just the value that's contained inside of either single or double quotes
     # E.g., if key = AMPLIFY_VERSION and the file contains: $AMPLIFY_VERSION = "1.3.3"
     # it will match 1.3.3
-    @regex_key = /(#{key}\s*=\s*["']\K)([\d\w.-]?)*/
+    @regex_key = /(#{key}\s*[=:]\s*["']?\K)([\d\w.-]?)*/
   end
 
   def match_and_replace_file(file:, value:)

--- a/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/version.rb
+++ b/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module ReleaseActions
-    VERSION = "1.0.4"
+    VERSION = "1.1.0"
   end
 end

--- a/src/fastlane/release_actions/spec/calculate_next_canary_version_spec.rb
+++ b/src/fastlane/release_actions/spec/calculate_next_canary_version_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+require 'actions/calculate_next_canary_version'
+
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "calculate_next_canary_version" do
+      example do
+        expect(Git).to receive(:last_tag).and_return('v1.0.2')
+        result = Fastlane::FastFile.new.parse("
+          lane :test do
+            calculate_next_canary_version
+          end
+        ").runner.execute(:test)
+        expect(result).to eq('1.0.3-unstable.0')
+      end
+
+      example do
+        expect(Git).to receive(:last_tag).and_return('v1.0.2')
+        result = Fastlane::FastFile.new.parse("
+          lane :test do
+            calculate_next_canary_version(prerelease_identifier: 'dev')
+          end
+        ").runner.execute(:test)
+        expect(result).to eq('1.0.3-dev.0')
+      end
+
+      example do
+        expect(Git).to receive(:last_tag).and_return('v1.0.3-dev.3')
+        result = Fastlane::FastFile.new.parse("
+          lane :test do
+            calculate_next_canary_version
+          end
+        ").runner.execute(:test)
+        expect(result).to eq('1.0.3-dev.4')
+      end
+
+      example do
+        expect(Git).to receive(:last_tag).and_return('v1.0.3-dev.3')
+        result = Fastlane::FastFile.new.parse("
+          lane :test do
+            calculate_next_canary_version(prerelease_identifier: 'anything')
+          end
+        ").runner.execute(:test)
+        expect(result).to eq('1.0.3-dev.4')
+      end
+    end
+  end
+end

--- a/src/fastlane/release_actions/spec/git_spec.rb
+++ b/src/fastlane/release_actions/spec/git_spec.rb
@@ -8,9 +8,26 @@ describe Git do
       expect(Git.last_tag).to eq('1.0.2')
     end
 
-    examples do
+    example do
       expect(Git).to receive(:run).and_return('v12.53.110-13-gabcdef0123')
       expect(Git.last_tag).to eq('v12.53.110')
+    end
+  end
+
+  describe '.last_release_tag' do
+    example do
+      expect(Git).to receive(:run).and_return("v1.0.5-alpha.1 v1.0.5-alpha.0 v1.0.4 v1.0.3 v0.10.0 v0.0.1 v0.0.1-preview.0")
+      expect(Git.last_release_tag).to eq('v1.0.4')
+    end
+
+    example do
+      expect(Git).to receive(:run).and_return("v1.10.0 v1.8.0")
+      expect(Git.last_release_tag).to eq('v1.10.0')
+    end
+
+    example do
+      expect(Git).to receive(:run).and_return("v1.10.0-dev.0\nv1.10.0\nv1.8.0\n\n")
+      expect(Git.last_release_tag).to eq('v1.10.0')
     end
   end
 end

--- a/src/fastlane/release_actions/spec/key_value_spec.rb
+++ b/src/fastlane/release_actions/spec/key_value_spec.rb
@@ -31,9 +31,22 @@ SWIFT_CONTENT_POST = <<~EOS
   }
 EOS
 
+YAML_CONTENT_PRE = <<~EOS
+  name: amplify_plugin
+  description: Some Amplify Flutter plugin.
+  version: 1.0.4
+EOS
+
+YAML_CONTENT_POST = <<~EOS
+  name: amplify_plugin
+  description: Some Amplify Flutter plugin.
+  version: 2.0.0
+EOS
+
 describe KeyValue do
   let(:spec_key_value) { KeyValue.new('AMPLIFY_VERSION') }
   let(:swift_key_value) { KeyValue.new('version') }
+  let(:yaml_key_value) { KeyValue.new('version') }
   let(:wrong_key_value) { KeyValue.new('HOLY_GRAIL') }
 
   describe '.match()' do
@@ -44,6 +57,11 @@ describe KeyValue do
 
     example do
       result = swift_key_value.match(SWIFT_CONTENT_PRE).to_s
+      expect(result).to eq('1.0.4')
+    end
+
+    example do
+      result = yaml_key_value.match(YAML_CONTENT_PRE).to_s
       expect(result).to eq('1.0.4')
     end
 
@@ -62,6 +80,11 @@ describe KeyValue do
     example do
       result = swift_key_value.replace(file_contents: SWIFT_CONTENT_PRE, value: '2.0.0').to_s
       expect(result).to eq(SWIFT_CONTENT_POST)
+    end
+
+    example do
+      result = yaml_key_value.replace(file_contents: YAML_CONTENT_PRE, value: '2.0.0').to_s
+      expect(result).to eq(YAML_CONTENT_POST)
     end
   end
 end


### PR DESCRIPTION
# Overview

This PR is the counterpart of #58 but for Flutter. It adds flexibility to the release_actions action so it's compatible with our needs.

## calculate_next_canary_version.rb

Adds support for pre-release identifiers other than `unstable`. Adds an option to set the pre-release identifier, with the default value `unstable` for backward compatibility. This is useful when `unstable` doesn't fit our needs, for example for `preview` releases.

Also added related rspec tests.

## git.rb

Updates the logic to retrieve the `last_release_tag`. This is needed to support the change in the previous section, by filtering out all pre-release tags (not just `unstable`). This is done by converting the tags into `Version`s and filter out all the pre-release versions. The change also fixes the issue where `v1.9.0` is considered later than `v1.10.0` in the original version using `sort -r`.

Also added related rspec tests.

<!--
My initial approach was simply Based on the spec of semver, a hyphen (`-`) should only occur in pre-release versions. The updated `last_release_tag` greps only tags without hyphens. This could lead to problems, for example when the release prefix includes a hyphen (see #58, consider the case if we use tags like `release-v1.0.0`), but seems to work fine with Amplify iOS and Android. It won't work with Amplify JS, because their tag has prefixes with hyphens.

The current approach uses a modified version of semver's [officially recommended regex](https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string). I changed it to remove the optional pre-release part, so it only matches release tags. This adds a little complexity but should be more robust.

```
(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
```

This approach likely also won't work with Amplify JS's tag naming scheme.
-->


## key_value.rb

Similar to #58, but adds support for YAML by matching a colon (`:`). Also added related spec tests.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
