### PR TITLE
chore: fix rubocop formatting and update Gemfile.lock

### DIFF
--- a/src/fastlane/release_actions/Gemfile.lock
+++ b/src/fastlane/release_actions/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-release_actions (1.0.4)
+    fastlane-plugin-release_actions (1.1.0)
 
 GEM
   remote: https://rubygems.org/
@@ -234,4 +234,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   2.1.2
+   2.1.4

--- a/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/helper/commit/commits.rb
+++ b/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/helper/commit/commits.rb
@@ -38,5 +38,4 @@ class Commits
   def empty?
     commits.empty?
   end
-
 end


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Remove empty line at the end of class `Commits`
* Update Gemfile.lock to latest version (1.1.0)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
