### PR TITLE
feat(iOS): Support custom endpoint for Cognito User Pool tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 aws_cdk.aws_apigateway
+aws_cdk.aws_cloudfront
+aws_cdk.aws_cloudfront_origins
 aws_cdk.aws_cloudtrail
 aws_cdk.aws_cloudwatch
 aws_cdk.aws_codebuild

--- a/src/integ_test_resources/ios/sdk/integration/cdk/setup.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/setup.py
@@ -14,6 +14,7 @@ setuptools.setup(
         "aws-cdk.aws-lambda",
         "aws-cdk.aws-apigateway",
         "aws-cdk.aws-cloudformation",
+        "aws-cdk.aws-cloudfront",
         "aws-cdk.aws-cognito",
         "aws-cdk.aws-iam",
         "aws-cdk.aws-ssm",


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/aws-sdk-ios/pull/3481

*Description of changes:*

- Adds CDK resources to support integ tests for custom endpoint support in a Cognito User Pool
- I will submit a formatting PR separately--we've started to drift from black/flake8/isort formats, and applying it to this PR would make it hard to distinguish functional changes from format changes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
