### PR TITLE
chore: Fix formatting; add flake8 & isort configs

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+exclude = cdk.out
+extend-ignore = E203, W503
+max-line-length = 100

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,7 @@
+[settings]
+ensure_newline_before_comments = True
+force_grid_wrap = 0
+include_trailing_comma = True
+line_length = 100
+multi_line_output = 3
+use_parentheses = True

--- a/src/integ_test_resources/ios/sdk/integration/cdk/app.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/app.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 from aws_cdk import core
-
 from cdk_integration_tests_ios.apigateway_stack import ApigatewayStack
 from cdk_integration_tests_ios.autoscaling_stack import AutoScalingStack
 from cdk_integration_tests_ios.cloudwatch_stack import CloudWatchStack

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/apigateway_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/apigateway_stack.py
@@ -1,5 +1,4 @@
 from aws_cdk import aws_apigateway, aws_lambda, core
-
 from common.common_stack import CommonStack
 from common.platforms import Platform
 from common.region_aware_stack import RegionAwareStack

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/autoscaling_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/autoscaling_stack.py
@@ -1,5 +1,4 @@
 from aws_cdk import aws_iam, core
-
 from common.common_stack import CommonStack
 from common.region_aware_stack import RegionAwareStack
 

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/cloudwatch_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/cloudwatch_stack.py
@@ -1,5 +1,4 @@
 from aws_cdk import aws_iam, core
-
 from common.common_stack import CommonStack
 from common.region_aware_stack import RegionAwareStack
 

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/cognito_idp_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/cognito_idp_stack.py
@@ -1,5 +1,4 @@
 from aws_cdk import aws_iam, core
-
 from common.common_stack import CommonStack
 from common.region_aware_stack import RegionAwareStack
 

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/comprehend_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/comprehend_stack.py
@@ -1,5 +1,4 @@
 from aws_cdk import aws_iam, core
-
 from common.common_stack import CommonStack
 from common.region_aware_stack import RegionAwareStack
 

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/core_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/core_stack.py
@@ -1,5 +1,4 @@
 from aws_cdk import aws_cognito, aws_iam, core
-
 from common.auth_utils import construct_identity_pool
 from common.common_stack import CommonStack
 from common.platforms import Platform

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/dynamodb_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/dynamodb_stack.py
@@ -1,5 +1,4 @@
 from aws_cdk import aws_iam, core
-
 from common.common_stack import CommonStack
 from common.region_aware_stack import RegionAwareStack
 

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/ec2_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/ec2_stack.py
@@ -1,5 +1,4 @@
 from aws_cdk import aws_iam, core
-
 from common.common_stack import CommonStack
 from common.region_aware_stack import RegionAwareStack
 

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/elb_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/elb_stack.py
@@ -1,5 +1,4 @@
 from aws_cdk import aws_iam, core
-
 from common.common_stack import CommonStack
 from common.region_aware_stack import RegionAwareStack
 
@@ -14,7 +13,7 @@ class ElbStack(RegionAwareStack):
             effect=aws_iam.Effect.ALLOW,
             actions=[
                 "elasticloadbalancing:DescribeAccountLimits",
-                "elasticloadbalancing:DescribeLoadBalancers"
+                "elasticloadbalancing:DescribeLoadBalancers",
             ],
             resources=["*"],
         )

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/firehose_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/firehose_stack.py
@@ -1,5 +1,4 @@
 from aws_cdk import aws_iam, aws_kinesisfirehose, aws_logs, aws_s3, core
-
 from common.common_stack import CommonStack
 from common.platforms import Platform
 from common.region_aware_stack import RegionAwareStack
@@ -142,7 +141,9 @@ class FirehoseStack(RegionAwareStack):
 
     def create_test_policies(self, common_stack):
         all_resources_policy = aws_iam.PolicyStatement(
-            effect=aws_iam.Effect.ALLOW, actions=["firehose:ListDeliveryStreams"], resources=["*"],
+            effect=aws_iam.Effect.ALLOW,
+            actions=["firehose:ListDeliveryStreams"],
+            resources=["*"],
         )
         common_stack.add_to_common_role_policies(self, policy_to_add=all_resources_policy)
 

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/iot_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/iot_stack.py
@@ -2,10 +2,10 @@ import hashlib
 import json
 
 from aws_cdk import aws_iam, aws_iot, aws_lambda, core, custom_resources
-
 from common.common_stack import CommonStack
 from common.platforms import Platform
 from common.region_aware_stack import RegionAwareStack
+
 
 class IotStack(RegionAwareStack):
     custom_auth_user_pass_username = "aws-sdk-user"
@@ -33,7 +33,9 @@ class IotStack(RegionAwareStack):
 
     def setup_iot_endpoint_provider(self):
         describe_endpoint_policy = aws_iam.PolicyStatement(
-            effect=aws_iam.Effect.ALLOW, actions=["iot:DescribeEndpoint"], resources=["*"],
+            effect=aws_iam.Effect.ALLOW,
+            actions=["iot:DescribeEndpoint"],
+            resources=["*"],
         )
 
         provider_lambda = aws_lambda.SingletonFunction(
@@ -102,7 +104,9 @@ class IotStack(RegionAwareStack):
         common_stack.add_to_common_role_policies(self, policy_to_add=topicfilter_policy)
 
         all_resources_policy = aws_iam.PolicyStatement(
-            effect=aws_iam.Effect.ALLOW, actions=["iot:CreateCertificateFromCsr"], resources=["*"],
+            effect=aws_iam.Effect.ALLOW,
+            actions=["iot:CreateCertificateFromCsr"],
+            resources=["*"],
         )
         common_stack.add_to_common_role_policies(self, policy_to_add=all_resources_policy)
 
@@ -140,7 +144,10 @@ class IotStack(RegionAwareStack):
         policy_name = f"iot_integ_test_policy_{md5_hash}"
 
         aws_iot.CfnPolicy(
-            self, "iot_integ_test_policy", policy_document=policy_document, policy_name=policy_name,
+            self,
+            "iot_integ_test_policy",
+            policy_document=policy_document,
+            policy_name=policy_name,
         )
         self._parameters_to_save["policy_name"] = policy_name
 
@@ -232,12 +239,17 @@ class IotStack(RegionAwareStack):
         self._parameters_to_save["custom_authorizer_user_pass_token_key_name"] = token_key_name
         token_value = "allow"
         self._parameters_to_save["custom_authorizer_user_pass_token_value"] = token_value
-        self._parameters_to_save["custom_authorizer_user_pass_username"] = self.custom_auth_user_pass_username
-        self._parameters_to_save["custom_authorizer_user_pass_password"] = self.custom_auth_user_pass_password
+        self._parameters_to_save[
+            "custom_authorizer_user_pass_username"
+        ] = self.custom_auth_user_pass_username
+        self._parameters_to_save[
+            "custom_authorizer_user_pass_password"
+        ] = self.custom_auth_user_pass_password
 
         iot_custom_authorizer_key_resource = self.create_custom_authorizer_signing_key_generic(
             "2",
-            "Manages an asymmetric CMK and token signature for iot custom authorizer with username and password.",
+            "Manages an asymmetric CMK and token signature for iot custom authorizer with "
+            "username and password.",
             token_value,
         )
 
@@ -248,15 +260,17 @@ class IotStack(RegionAwareStack):
             "custom_authorizer_user_pass_token_signature"
         ] = custom_authorizer_token_signature
 
-        # TODO: remove forcing of us-east-1 when enhanced custom authorizers are available in all regions
-        # Force region to 'us-east-1' due to enhanced custom authorizers only available in this region
+        # Force region to 'us-east-1' due to enhanced custom authorizers only available there
+        # TODO: remove override when enhanced custom authorizers are available in all regions
         authorizer_function_arn = self.setup_custom_authorizer_function(
             "2",
             "custom_resources/iot_custom_authorizer_user_pass_function",
             "iot_custom_authorizer_user_pass.handler",
             "Sample custom authorizer that allows or denies based on username and password",
-            {"custom_auth_user_pass_username": self.custom_auth_user_pass_username,
-             "custom_auth_user_pass_password": self.custom_auth_user_pass_password},
+            {
+                "custom_auth_user_pass_username": self.custom_auth_user_pass_username,
+                "custom_auth_user_pass_password": self.custom_auth_user_pass_password,
+            },
             "us-east-1",
         )
         create_authorizer_policy = aws_iam.PolicyStatement(
@@ -279,10 +293,17 @@ class IotStack(RegionAwareStack):
             runtime=aws_lambda.Runtime.PYTHON_3_7,
             code=aws_lambda.Code.asset("custom_resources/iot_custom_authorizer_user_pass_provider"),
             handler="iot_custom_authorizer_user_pass_provider.on_event",
-            description="Sets up an IoT custom authorizer for user password & required domain config due to beta status",
-            environment={"custom_auth_user_pass_uuid" : self.custom_auth_user_pass_uuid,
-                         "custom_auth_user_pass_default_authorizer_name" : self.custom_auth_user_pass_default_authorizer_name,
-                         "custom_auth_user_pass_domain_configuration_name" : self.custom_auth_user_pass_domain_configuration_name},
+            description="Sets up an IoT custom authorizer for user password & required domain "
+            "config due to beta status",
+            environment={
+                "custom_auth_user_pass_uuid": self.custom_auth_user_pass_uuid,
+                "custom_auth_user_pass_default_authorizer_name": (
+                    self.custom_auth_user_pass_default_authorizer_name
+                ),
+                "custom_auth_user_pass_domain_configuration_name": (
+                    self.custom_auth_user_pass_domain_configuration_name
+                ),
+            },
             current_version_options=aws_lambda.VersionOptions(
                 removal_policy=core.RemovalPolicy.DESTROY
             ),
@@ -333,7 +354,7 @@ class IotStack(RegionAwareStack):
             current_version_options=aws_lambda.VersionOptions(
                 removal_policy=core.RemovalPolicy.DESTROY
             ),
-            environment=merged_environment_vars
+            environment=merged_environment_vars,
         )
 
         authorizer_function.grant_invoke(aws_iam.ServicePrincipal("iot.amazonaws.com"))

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/kinesis_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/kinesis_stack.py
@@ -1,5 +1,4 @@
 from aws_cdk import aws_iam, core
-
 from common.common_stack import CommonStack
 from common.platforms import Platform
 from common.region_aware_stack import RegionAwareStack
@@ -12,7 +11,9 @@ class KinesisStack(RegionAwareStack):
         self._supported_in_region = self.is_service_supported_in_region()
 
         all_resources_policy = aws_iam.PolicyStatement(
-            effect=aws_iam.Effect.ALLOW, actions=["kinesis:ListStreams"], resources=["*"],
+            effect=aws_iam.Effect.ALLOW,
+            actions=["kinesis:ListStreams"],
+            resources=["*"],
         )
         common_stack.add_to_common_role_policies(self, policy_to_add=all_resources_policy)
 

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/kinesisvideo_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/kinesisvideo_stack.py
@@ -1,5 +1,4 @@
 from aws_cdk import aws_iam, core
-
 from common.common_stack import CommonStack
 from common.platforms import Platform
 from common.region_aware_stack import RegionAwareStack
@@ -12,7 +11,9 @@ class KinesisVideoStack(RegionAwareStack):
         self._supported_in_region = self.is_service_supported_in_region()
 
         all_resources_policy = aws_iam.PolicyStatement(
-            effect=aws_iam.Effect.ALLOW, actions=["kinesisvideo:ListStreams"], resources=["*"],
+            effect=aws_iam.Effect.ALLOW,
+            actions=["kinesisvideo:ListStreams"],
+            resources=["*"],
         )
         common_stack.add_to_common_role_policies(self, policy_to_add=all_resources_policy)
 

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/kms_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/kms_stack.py
@@ -1,5 +1,4 @@
 from aws_cdk import aws_iam, core
-
 from common.common_stack import CommonStack
 from common.region_aware_stack import RegionAwareStack
 
@@ -11,7 +10,9 @@ class KmsStack(RegionAwareStack):
         self._supported_in_region = self.is_service_supported_in_region()
 
         all_resources_policy = aws_iam.PolicyStatement(
-            effect=aws_iam.Effect.ALLOW, actions=["kms:CreateKey"], resources=["*"],
+            effect=aws_iam.Effect.ALLOW,
+            actions=["kms:CreateKey"],
+            resources=["*"],
         )
         common_stack.add_to_common_role_policies(self, policy_to_add=all_resources_policy)
 

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/lambda_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/lambda_stack.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 
 from aws_cdk import aws_lambda, core
-
 from common.common_stack import CommonStack
 from common.file_utils import replace_in_file
 from common.platforms import Platform

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/mobileclient_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/mobileclient_stack.py
@@ -1,8 +1,15 @@
 from typing import List, Optional
 
-from aws_cdk import (aws_cloudfront, aws_cloudfront_origins, aws_cognito, aws_iam, aws_lambda, aws_s3, core,
-                     custom_resources)
-
+from aws_cdk import (
+    aws_cloudfront,
+    aws_cloudfront_origins,
+    aws_cognito,
+    aws_iam,
+    aws_lambda,
+    aws_s3,
+    core,
+    custom_resources,
+)
 from common.auth_utils import construct_identity_pool
 from common.common_stack import CommonStack
 from common.platforms import Platform
@@ -63,7 +70,7 @@ class MobileClientStack(RegionAwareStack):
             default_user_pool_client_secret,
             None,
             "CustomEndpoint",
-            custom_endpoint=custom_endpoint
+            custom_endpoint=custom_endpoint,
         )
 
         self.create_custom_auth_user_pool(default_user_pool, default_user_pool_client)
@@ -133,9 +140,8 @@ class MobileClientStack(RegionAwareStack):
             self,
             f"cloudfront_userpool_{tag}",
             default_behavior=aws_cloudfront.BehaviorOptions(
-                allowed_methods=aws_cloudfront.AllowedMethods.ALLOW_ALL,
-                origin=origin
-            )
+                allowed_methods=aws_cloudfront.AllowedMethods.ALLOW_ALL, origin=origin
+            ),
         )
 
         return distribution.domain_name
@@ -178,7 +184,10 @@ class MobileClientStack(RegionAwareStack):
             ),
             schema=[
                 aws_cognito.CfnUserPool.SchemaAttributeProperty(
-                    attribute_data_type="String", mutable=False, name="email", required=True,
+                    attribute_data_type="String",
+                    mutable=False,
+                    name="email",
+                    required=True,
                 ),
                 aws_cognito.CfnUserPool.SchemaAttributeProperty(
                     attribute_data_type="String",
@@ -238,7 +247,10 @@ class MobileClientStack(RegionAwareStack):
     ) -> aws_cognito.CfnUserPoolClient:
         if not federation_providers:
             user_pool_client = aws_cognito.CfnUserPoolClient(
-                self, f"userpool_client_{tag}", generate_secret=True, user_pool_id=user_pool.ref,
+                self,
+                f"userpool_client_{tag}",
+                generate_secret=True,
+                user_pool_id=user_pool.ref,
             )
             return user_pool_client
 
@@ -319,7 +331,10 @@ class MobileClientStack(RegionAwareStack):
     def create_user_pool_domain(self, user_pool: aws_cognito.CfnUserPool, tag: str):
         domain_prefix = self._secrets["hostedui.domain_prefix"]
         domain = aws_cognito.CfnUserPoolDomain(
-            self, f"user_pool_domain_{tag}", domain=domain_prefix, user_pool_id=user_pool.ref,
+            self,
+            f"user_pool_domain_{tag}",
+            domain=domain_prefix,
+            user_pool_id=user_pool.ref,
         )
         return domain
 

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/pinpoint_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/pinpoint_stack.py
@@ -1,5 +1,4 @@
 from aws_cdk import aws_iam, aws_pinpoint, core
-
 from common.common_stack import CommonStack
 from common.platforms import Platform
 from common.region_aware_stack import RegionAwareStack
@@ -17,7 +16,9 @@ class PinpointStack(RegionAwareStack):
         self._parameters_to_save["app_id"] = pinpoint_app.ref
 
         legacy_mobileanalytics_policy = aws_iam.PolicyStatement(
-            effect=aws_iam.Effect.ALLOW, actions=["mobileanalytics:PutEvents"], resources=["*"],
+            effect=aws_iam.Effect.ALLOW,
+            actions=["mobileanalytics:PutEvents"],
+            resources=["*"],
         )
         common_stack.add_to_common_role_policies(self, policy_to_add=legacy_mobileanalytics_policy)
 

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/polly_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/polly_stack.py
@@ -1,5 +1,4 @@
 from aws_cdk import aws_iam, aws_s3, core
-
 from common.common_stack import CommonStack
 from common.platforms import Platform
 from common.region_aware_stack import RegionAwareStack

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/rekognition_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/rekognition_stack.py
@@ -1,5 +1,4 @@
 from aws_cdk import aws_iam, core
-
 from common.common_stack import CommonStack
 from common.region_aware_stack import RegionAwareStack
 

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/s3_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/s3_stack.py
@@ -1,5 +1,4 @@
 from aws_cdk import aws_iam, aws_s3, core
-
 from common.common_stack import CommonStack
 from common.platforms import Platform
 from common.region_aware_stack import RegionAwareStack

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/ses_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/ses_stack.py
@@ -1,5 +1,4 @@
 from aws_cdk import aws_iam, core
-
 from common.common_stack import CommonStack
 from common.region_aware_stack import RegionAwareStack
 

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/simpledb_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/simpledb_stack.py
@@ -1,5 +1,4 @@
 from aws_cdk import aws_iam, core
-
 from common.common_stack import CommonStack
 from common.platforms import Platform
 from common.region_aware_stack import RegionAwareStack

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/sns_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/sns_stack.py
@@ -1,5 +1,4 @@
 from aws_cdk import aws_iam, core
-
 from common.common_stack import CommonStack
 from common.region_aware_stack import RegionAwareStack
 
@@ -11,6 +10,8 @@ class SnsStack(RegionAwareStack):
         self._supported_in_region = self.is_service_supported_in_region()
 
         stack_policy = aws_iam.PolicyStatement(
-            effect=aws_iam.Effect.ALLOW, actions=["sns:ListTopics"], resources=["*"],
+            effect=aws_iam.Effect.ALLOW,
+            actions=["sns:ListTopics"],
+            resources=["*"],
         )
         common_stack.add_to_common_role_policies(self, policy_to_add=stack_policy)

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/sqs_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/sqs_stack.py
@@ -1,5 +1,4 @@
 from aws_cdk import aws_iam, aws_sqs, core
-
 from common.common_stack import CommonStack
 from common.region_aware_stack import RegionAwareStack
 
@@ -21,6 +20,8 @@ class SqsStack(RegionAwareStack):
         common_stack.add_to_common_role_policies(self, policy_to_add=queue_policy)
 
         all_resources_policy = aws_iam.PolicyStatement(
-            effect=aws_iam.Effect.ALLOW, actions=["sqs:ListQueues"], resources=["*"],
+            effect=aws_iam.Effect.ALLOW,
+            actions=["sqs:ListQueues"],
+            resources=["*"],
         )
         common_stack.add_to_common_role_policies(self, policy_to_add=all_resources_policy)

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/sts_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/sts_stack.py
@@ -1,5 +1,4 @@
 from aws_cdk import aws_iam, core
-
 from common.common_stack import CommonStack
 from common.platforms import Platform
 from common.region_aware_stack import RegionAwareStack

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/textract_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/textract_stack.py
@@ -1,5 +1,4 @@
 from aws_cdk import aws_iam, core
-
 from common.common_stack import CommonStack
 from common.platforms import Platform
 from common.region_aware_stack import RegionAwareStack

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/transcribe_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/transcribe_stack.py
@@ -1,5 +1,4 @@
 from aws_cdk import aws_iam, aws_s3, core
-
 from common.common_stack import CommonStack
 from common.platforms import Platform
 from common.region_aware_stack import RegionAwareStack

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/translate_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/translate_stack.py
@@ -1,5 +1,4 @@
 from aws_cdk import aws_iam, core
-
 from common.common_stack import CommonStack
 from common.region_aware_stack import RegionAwareStack
 

--- a/src/integ_test_resources/ios/sdk/integration/cdk/custom_resources/iot_custom_authorizer_key_provider/iot_custom_authorizer_key_provider.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/custom_resources/iot_custom_authorizer_key_provider/iot_custom_authorizer_key_provider.py
@@ -110,7 +110,10 @@ def sign(key_id, token_value):
     client = boto3.client("kms")
     token_bytes = bytes(token_value, "utf8")
     sign_response = client.sign(
-        KeyId=key_id, Message=token_bytes, MessageType="RAW", SigningAlgorithm=SIGNING_ALGORITHM,
+        KeyId=key_id,
+        Message=token_bytes,
+        MessageType="RAW",
+        SigningAlgorithm=SIGNING_ALGORITHM,
     )
     print(f"### sign_response: {sign_response}")
     data = sign_response["Signature"]

--- a/src/integ_test_resources/ios/sdk/integration/cdk/custom_resources/iot_custom_authorizer_user_pass_function/iot_custom_authorizer_user_pass.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/custom_resources/iot_custom_authorizer_user_pass_function/iot_custom_authorizer_user_pass.py
@@ -1,6 +1,7 @@
-import json
 import base64
+import json
 import os
+
 
 def handler(event, __):
     print(f"### handler: {event}")
@@ -14,7 +15,11 @@ def handler(event, __):
     base64_decoded = base64.b64decode(password).decode("utf-8")
     passwordMatches = expected_password == base64_decoded
 
-    effect = "Allow" if token == "allow" and mqtt_user.startswith(expected_username) and passwordMatches else "Deny"
+    effect = (
+        "Allow"
+        if token == "allow" and mqtt_user.startswith(expected_username) and passwordMatches
+        else "Deny"
+    )
 
     response = make_auth_response(effect)
     response_string = json.dumps(response)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Added `black`-compatible configs for `flake8` and `isort`
- Fixed issues throughout ios sub-tree

This is in draft mode until I can confirm all tests pass with resources created after the formatting changes. I'm not particularly concerned about any of them, but the IoT custom resolvers in particular would be useful to verify

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
