### PR TITLE
chore(android): add CodeBuild project for release automation

### DIFF
--- a/src/build_infrastructure/android/amplify_custom_resources/__init__.py
+++ b/src/build_infrastructure/android/amplify_custom_resources/__init__.py
@@ -3,4 +3,5 @@ import sys
 from .device_farm_project import DeviceFarmProject
 from .device_farm_device_pool import DeviceFarmDevicePool
 from .pull_request_builder import PullRequestBuilder
+from .maven_release_publisher import MavenPublisher
 sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), "."))

--- a/src/build_infrastructure/android/amplify_custom_resources/maven_release_publisher.py
+++ b/src/build_infrastructure/android/amplify_custom_resources/maven_release_publisher.py
@@ -20,7 +20,7 @@ class MavenPublisher(Project):
                     buildspec_path,
                     environment_variables = {},
                     base_branch: str = "main",
-                    release_branch: str = "release"):
+                    release_branch: str = "bump_version"):
 
         build_environment = BuildEnvironment(build_image=self.BUILD_IMAGE, privileged = True, compute_type = ComputeType.LARGE)
 

--- a/src/build_infrastructure/android/amplify_custom_resources/maven_release_publisher.py
+++ b/src/build_infrastructure/android/amplify_custom_resources/maven_release_publisher.py
@@ -24,7 +24,7 @@ class MavenPublisher(Project):
 
         build_environment = BuildEnvironment(build_image=self.BUILD_IMAGE, privileged = True, compute_type = ComputeType.LARGE)
 
-        trigger_on_pr_merged = FilterGroup.in_event_of(EventAction.PULL_REQUEST_MERGED).and_base_branch_is(base_branch).and_branch_is(release_branch).and_commit_message_is("chore(release).*")
+        trigger_on_pr_merged = FilterGroup.in_event_of(EventAction.PULL_REQUEST_MERGED).and_base_branch_is(base_branch).and_branch_is(release_branch).and_commit_message_is("release:.*")
             
         super().__init__(scope, id,
             project_name = project_name,

--- a/src/build_infrastructure/android/amplify_custom_resources/maven_release_publisher.py
+++ b/src/build_infrastructure/android/amplify_custom_resources/maven_release_publisher.py
@@ -1,0 +1,39 @@
+
+from aws_cdk import core
+from aws_cdk.aws_codebuild import (
+    BuildEnvironment,
+    BuildSpec,
+    ComputeType,
+    EventAction,
+    FilterGroup,
+    LinuxBuildImage,
+    Project,
+    Source
+)
+
+class MavenPublisher(Project):
+    BUILD_IMAGE = LinuxBuildImage.AMAZON_LINUX_2_3
+    def __init__(self, scope: core.Construct, id: str, *,
+                    project_name: str,
+                    github_owner,
+                    github_repo,
+                    buildspec_path,
+                    environment_variables = {},
+                    base_branch: str = "main",
+                    release_branch: str = "release"):
+
+        build_environment = BuildEnvironment(build_image=self.BUILD_IMAGE, privileged = True, compute_type = ComputeType.LARGE)
+
+        trigger_on_pr_merged = FilterGroup.in_event_of(EventAction.PULL_REQUEST_MERGED).and_base_branch_is(base_branch).and_branch_is(release_branch).and_commit_message_is("chore(release).*")
+            
+        super().__init__(scope, id,
+            project_name = project_name,
+            environment_variables = environment_variables,
+            build_spec=BuildSpec.from_source_filename(buildspec_path),
+            badge = True,
+            source = Source.git_hub(owner = github_owner,
+                                    report_build_status = True,
+                                    repo = github_repo, 
+                                    webhook = True,
+                                    webhook_filters = [trigger_on_pr_merged]),
+            environment = build_environment)

--- a/src/build_infrastructure/android/app.py
+++ b/src/build_infrastructure/android/app.py
@@ -8,6 +8,7 @@ from aws_cdk import (
 
 from stacks.build_pipeline_stack import AmplifyAndroidCodePipeline
 from stacks.account_bootstrap_stack import AccountBootstrap
+from stacks.maven_release_stack import MavenReleaseStack
 
 app = core.App()
 TARGET_REGION = app.node.try_get_context("region")
@@ -18,11 +19,15 @@ REPO='amplify-android'
 github_owner=app.node.try_get_context("github_owner")
 branch=app.node.try_get_context("branch")
 config_source_bucket = app.node.try_get_context("config_source_bucket")
-print(f"AWS Account={TARGET_ACCOUNT} Region={TARGET_REGION}")
+release_pr_branch = app.node.try_get_context("release_pr_branch")
 log_level=app.node.try_get_context("log_level")
 
+print(f"AWS Account={TARGET_ACCOUNT} Region={TARGET_REGION}")
+
+# Account bootstrap stack
 account_bootstrap = AccountBootstrap(app, "AccountBootstrap", {}, env=TARGET_ENV)
 
+# Unit and integration test stack
 code_pipeline_stack_props = {
     # If set, config files for tests will be copied from S3. Otherwise, it will attempt to retrieve using the Amplify CLI
     'config_source_bucket': account_bootstrap.config_source_bucket.bucket_name, 
@@ -40,6 +45,19 @@ pipeline_stack = AmplifyAndroidCodePipeline(app,
                                     code_pipeline_stack_props,
                                     description="CI Pipeline assets for amplify-android",
                                     env=TARGET_ENV)
+
+# Maven publisher stack
+maven_publisher_stack_props = {
+    'github_source': { 
+        'owner': github_owner,
+        'repo': REPO, 
+        'base_branch': branch,
+        'release_pr_branch': release_pr_branch
+    },
+    'codebuild_project_name_prefix': 'AmplifyAndroid'
+}
+
+MavenReleaseStack(app, "MavenPublisher", maven_publisher_stack_props, description="Assets used for publishing amplify-android to maven.", env=TARGET_ENV)
 
 
 app.synth()

--- a/src/build_infrastructure/android/stacks/maven_release_stack.py
+++ b/src/build_infrastructure/android/stacks/maven_release_stack.py
@@ -1,0 +1,28 @@
+from aws_cdk import (
+    core
+)
+
+from amplify_custom_resources import MavenPublisher
+
+class MavenReleaseStack(core.Stack):
+    def __init__(self, scope: core.App, id: str, props, **kwargs) -> None:
+        super().__init__(scope, id, **kwargs)
+
+        required_props = ['github_source']
+        for prop in required_props:
+            if prop not in props:
+                raise RuntimeError(f"Parameter {prop} is required.")
+        
+        codebuild_project_name_prefix = props['codebuild_project_name_prefix']
+
+        github_source = props['github_source']
+        owner = github_source['owner']
+        repo = github_source['repo']
+        base_branch = github_source['base_branch']
+
+
+        MavenPublisher(self, "ReleasePublisher", project_name=f"{codebuild_project_name_prefix}-ReleasePublisher",
+                                                   github_owner=owner, 
+                                                   github_repo=repo, 
+                                                   base_branch=base_branch,
+                                                   buildspec_path="scripts/maven-release-publisher.yml")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
CodeBuild project for the buildspec file defined in [this PR](https://github.com/aws-amplify/amplify-android/pull/1271)

This PR adds a new stack with a CodeBuild project triggered by PR merges that meet certain base branch, source branch and commit message requirements.

It can also be triggered manually via the console or the AWS CLI.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
