### PR TITLE
feat: Add AdminUpdateUserAttributes permission for forgot password test

### DIFF
--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/cognito_idp_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/cognito_idp_stack.py
@@ -19,7 +19,11 @@ class CognitoIdpStack(RegionAwareStack):
         )
         specified_resources_policy = aws_iam.PolicyStatement(
             effect=aws_iam.Effect.ALLOW,
-            actions=["cognito-idp:AdminConfirmSignUp", "cognito-idp:CreateUserPoolClient"],
+            actions=[
+                "cognito-idp:AdminConfirmSignUp",
+                "cognito-idp:AdminUpdateUserAttributes",
+                "cognito-idp:CreateUserPoolClient"
+            ],
             resources=[specified_resources_arn],
         )
         common_stack.add_to_common_role_policies(self, policy_to_add=specified_resources_policy)


### PR DESCRIPTION
To support "forgot password" test in the AWSMobileClient tests, we want the ability to confirm an email address via `AdminUpdateUserAttributes`. This supports a future PR in the aws-sdk-ios repo.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
