### PR TITLE
feat: Change the credential rotator to use json event data

### DIFF
--- a/src/release_artifacts_resources/ios/cdk/cdk/credential_rotation/events_construct.py
+++ b/src/release_artifacts_resources/ios/cdk/cdk/credential_rotation/events_construct.py
@@ -1,3 +1,6 @@
+import json
+import os
+
 from aws_cdk import aws_events, aws_events_targets, core
 from cdk.credential_rotation.lambda_construct import LambdaConstruct
 
@@ -7,9 +10,16 @@ class EventsConstruct(core.Construct):
         self, scope: core.Construct, construct_id: str, lambda_construct: LambdaConstruct, **kwargs
     ) -> None:
         super().__init__(scope, construct_id, **kwargs)
+        file_name = os.path.join(os.path.dirname(__file__), "./utils/lambda_event_data.json")
+        event_data_file = open(file_name, "r")
+        event_data = json.loads(event_data_file.read())
+        rule_target = aws_events.RuleTargetInput.from_object(event_data)
 
-        target = aws_events_targets.LambdaFunction(lambda_construct.credential_rotator)
+        target = aws_events_targets.LambdaFunction(
+            handler=lambda_construct.credential_rotator, event=rule_target
+        )
         schedule_duration = core.Duration.hours(2)
+
         aws_events.Rule(
             self,
             "credential_rotator_event",

--- a/src/release_artifacts_resources/ios/cdk/cdk/credential_rotation/lambda_construct.py
+++ b/src/release_artifacts_resources/ios/cdk/cdk/credential_rotation/lambda_construct.py
@@ -31,8 +31,13 @@ class LambdaConstruct(core.Construct):
             ),
         )
         self.credential_rotator.add_environment(
-            lambda_constants.CIRCLECI_CONFIG_SECRET_ENV,
-            secretsmanager_construct.circleci_api_key.secret_full_arn,
+            lambda_constants.CIRCLE_CI_IOS_SDK_API_TOKEN_ENV,
+            secretsmanager_construct.circleci_aws_ios_sdk_api_key.secret_full_arn,
+        )
+
+        self.credential_rotator.add_environment(
+            lambda_constants.CIRCLE_CI_IOS_SDK_SPM_API_TOKEN_ENV,
+            secretsmanager_construct.circleci_aws_ios_sdk_spm_api_key.secret_full_arn,
         )
 
         self.credential_rotator.add_environment(
@@ -41,7 +46,7 @@ class LambdaConstruct(core.Construct):
         )
 
         self.credential_rotator.add_environment(
-            lambda_constants.CIRCLECI_EXECUTION_ROLE_ENV,
+            lambda_constants.IAM_ROLE_ENV,
             iam_construct.circleci_release_role.role_arn,
         )
 

--- a/src/release_artifacts_resources/ios/cdk/cdk/credential_rotation/lambda_functions/src/destination/circleci.py
+++ b/src/release_artifacts_resources/ios/cdk/cdk/credential_rotation/lambda_functions/src/destination/circleci.py
@@ -21,8 +21,8 @@ The actual process is quite simple
    environment variables, authenticating with the **CircleCI API token**
 """
 import requests
-from src.utils.retry import retry
-from src.utils.secrets_manager_helper import retrieve_secret
+from utils.retry import retry
+from utils.secrets_manager_helper import retrieve_secret
 
 CIRCLECI_URL_TEMPLATE = "https://circleci.com/api/v2/project/gh/{project_path}/envvar"
 

--- a/src/release_artifacts_resources/ios/cdk/cdk/credential_rotation/lambda_functions/src/models/destination_type.py
+++ b/src/release_artifacts_resources/ios/cdk/cdk/credential_rotation/lambda_functions/src/models/destination_type.py
@@ -1,7 +1,7 @@
 from enum import Enum
 
 
-class DestinationType(Enum):
+class DestinationType(str, Enum):
     """A destination that rotated values are pushed to"""
 
     CIRCLECI_ENVIRONMENT_VARIABLE = "cci_env_variable"

--- a/src/release_artifacts_resources/ios/cdk/cdk/credential_rotation/lambda_functions/src/models/source_type.py
+++ b/src/release_artifacts_resources/ios/cdk/cdk/credential_rotation/lambda_functions/src/models/source_type.py
@@ -1,7 +1,7 @@
 from enum import Enum
 
 
-class SourceType(Enum):
+class SourceType(str, Enum):
     """The source of a value to push to a destination"""
 
     AWS_SESSION_CREDENTIALS = "aws_session_credentials"

--- a/src/release_artifacts_resources/ios/cdk/cdk/credential_rotation/lambda_functions/src/source_data_generator/aws_session_credential_source.py
+++ b/src/release_artifacts_resources/ios/cdk/cdk/credential_rotation/lambda_functions/src/source_data_generator/aws_session_credential_source.py
@@ -8,7 +8,7 @@ from time import sleep
 from typing import Dict, Tuple
 
 import boto3
-from src.utils.retry import retry
+from utils.retry import retry
 
 DEFAULT_REGION = "us-west-2"
 
@@ -77,6 +77,7 @@ def get_session_credentials(
     if not sts:
         sts = boto3.client(
             "sts",
+            region_name=REGION,
             aws_access_key_id=credentials[0],
             aws_secret_access_key=credentials[1],
         )

--- a/src/release_artifacts_resources/ios/cdk/cdk/credential_rotation/lambda_functions/src/source_data_generator/secrets_data_source.py
+++ b/src/release_artifacts_resources/ios/cdk/cdk/credential_rotation/lambda_functions/src/source_data_generator/secrets_data_source.py
@@ -1,7 +1,7 @@
 import json
 from typing import Dict
 
-from src.utils.secrets_manager_helper import retrieve_secret
+from utils.secrets_manager_helper import retrieve_secret
 
 
 def retrieve_secrets(configuration: map) -> Dict[str, str]:

--- a/src/release_artifacts_resources/ios/cdk/cdk/credential_rotation/secretsmanager_construct.py
+++ b/src/release_artifacts_resources/ios/cdk/cdk/credential_rotation/secretsmanager_construct.py
@@ -9,11 +9,17 @@ class SecretsManagerConstruct(core.Construct):
     ) -> None:
         super().__init__(scope, construct_id, **kwargs)
 
-        self.circleci_api_key = aws_secretsmanager.Secret(
+        self.circleci_aws_ios_sdk_api_key = aws_secretsmanager.Secret(
             self,
-            "circleCI_API_key",
-            description="CircleCI API key used by credential rotator lambda",
-            secret_name=constants.CIRCLECI_API_KEY,
+            "circleCI_AWS_iOS_SDK_API_key",
+            description="CircleCI API key used by credential rotator lambda for AWS iOS SDK",
+            secret_name=constants.CIRCLECI_AWS_IOS_SDK_API_KEY,
+        )
+        self.circleci_aws_ios_sdk_spm_api_key = aws_secretsmanager.Secret(
+            self,
+            "circleCI_AWS_iOS_SDK_SPM_API_key",
+            description="CircleCI API key used by credential rotator lambda for AWS iOS SDK SPM",
+            secret_name=constants.CIRCLECI_AWS_IOS_SDK_SPM_API_KEY,
         )
         self.github_release_api_key = aws_secretsmanager.Secret(
             self,
@@ -28,7 +34,8 @@ class SecretsManagerConstruct(core.Construct):
             effect=aws_iam.Effect.ALLOW,
             actions=["secretsmanager:GetSecretValue"],
             resources=[
-                self.circleci_api_key.secret_full_arn,
+                self.circleci_aws_ios_sdk_api_key.secret_full_arn,
+                self.circleci_aws_ios_sdk_spm_api_key.secret_full_arn,
                 self.github_release_api_key.secret_full_arn,
             ],
         )

--- a/src/release_artifacts_resources/ios/cdk/cdk/credential_rotation/utils/lambda_constants.py
+++ b/src/release_artifacts_resources/ios/cdk/cdk/credential_rotation/utils/lambda_constants.py
@@ -1,10 +1,14 @@
 # Lambda environment variable key, whose value is the
 # SecretsManager secret name of the CIrcleCI API key
-CIRCLECI_CONFIG_SECRET_ENV = "CIRCLECI_CONFIG_SECRET"
+CIRCLE_CI_IOS_SDK_API_TOKEN_ENV = "CIRCLE_CI_IOS_SDK_API_TOKEN"
+
+# Lambda environment variable key, whose value is the
+# SecretsManager secret name of the CIrcleCI API key
+CIRCLE_CI_IOS_SDK_SPM_API_TOKEN_ENV = "CIRCLE_CI_IOS_SDK_SPM_API_TOKEN"
 
 # Lambda environment variable key, whose value is the
 # ARN of the Lambda execution IAM role
-CIRCLECI_EXECUTION_ROLE_ENV = "CIRCLECI_EXECUTION_ROLE"
+IAM_ROLE_ENV = "IAM_ROLE"
 
 # Lambda environment variable key, whose value is the
 # IAM user for whom the rotator will generate static
@@ -24,9 +28,9 @@ GITHUB_CREDENTIALS_SECRET_ENV = "GITHUB_CREDENTIALS_SECRET"
 
 # Lambda environment variable key, whose value is the
 # bucket name where release artifacts are uploaded
-RELEASE_BUCKET_NAME_ENV = "RELEASE_BUCKET_NAME"
+RELEASE_BUCKET_NAME_ENV = "SPM_S3_BUCKET_NAME"
 
 # Lambda environment variable key, whose value is the
 # CloudFront distribution id that gets invalidated during
 # binary artifact releases.
-RELEASE_CLOUDFRONT_DISTRIBUTION_ID_ENV = "RELEASE_CLOUDFRONT_DISTRIBUTION_ID"
+RELEASE_CLOUDFRONT_DISTRIBUTION_ID_ENV = "SPM_RELEASE_CLOUDFRONT_DISTRIBUTION_ID"

--- a/src/release_artifacts_resources/ios/cdk/cdk/credential_rotation/utils/lambda_event_data.json
+++ b/src/release_artifacts_resources/ios/cdk/cdk/credential_rotation/utils/lambda_event_data.json
@@ -1,0 +1,113 @@
+{
+  "sources": [
+    {
+      "type": "aws_session_credentials",
+      "description": "Temporary AWS Credentials to upload the release artifacts to S3 and invalidate Cloudfront",
+      "configuration": {
+        "user_env_variable": "IAM_USERNAME",
+        "iam_role_env_variable": "IAM_ROLE"
+      },
+      "destination": {
+        "specifier": "aws-sdk-ios-cci",
+        "mapping_to_destination": [
+          {
+            "destination_key_name": "XCF_AWS_ACCESS_KEY_ID",
+            "result_value_key": "access_key_id"
+          },
+          {
+            "destination_key_name": "XCF_AWS_SECRET_ACCESS_KEY",
+            "result_value_key": "secret_access_key"
+          },
+          {
+            "destination_key_name": "XCF_AWS_SESSION_TOKEN",
+            "result_value_key": "session_token"
+          }
+        ]
+      }
+    },
+    {
+      "type": "secrets_manager",
+      "description": "GITHUB credentials to be used in aws-sdk-ios circleci scripts",
+      "configuration": {
+        "secret_key_env_variable": "GITHUB_CREDENTIALS_SECRET"
+      },
+      "destination": {
+        "specifier": "aws-sdk-ios-cci",
+        "mapping_to_destination": [
+          {
+            "destination_key_name": "GITHUB_SPM_RELEASE_TOKEN",
+            "result_value_key": "GITHUB_SPM_TOKEN"
+          },
+          {
+            "destination_key_name": "GITHUB_SPM_RELEASE_USER",
+            "result_value_key": "GITHUB_SPM_USER"
+          }
+        ]
+      }
+    },
+    {
+      "type": "secrets_manager",
+      "description": "GITHUB credentials to be used in aws-sdk-ios-spm circleci scripts",
+      "configuration": {
+        "secret_key_env_variable": "GITHUB_CREDENTIALS_SECRET"
+      },
+      "destination": {
+        "specifier": "aws-sdk-ios-spm-cci",
+        "mapping_to_destination": [
+          {
+            "destination_key_name": "GITHUB_SPM_RELEASE_TOKEN",
+            "result_value_key": "GITHUB_SPM_TOKEN"
+          },
+          {
+            "destination_key_name": "GITHUB_SPM_RELEASE_USER",
+            "result_value_key": "GITHUB_SPM_USER"
+          }
+        ]
+      }
+    },
+    {
+      "type": "lambda_environment_variable",
+      "description": "S3 bucket name used to upload the binary artifacts",
+      "configuration": {
+        "lambda_env_var_key": "SPM_S3_BUCKET_NAME"
+      },
+      "destination": {
+        "specifier": "aws-sdk-ios-cci",
+        "mapping_to_destination": [
+          {
+            "destination_key_name": "XCF_RELEASE_BUCKET"
+          }
+        ]
+      }
+    },
+    {
+      "type": "lambda_environment_variable",
+      "description": "Release cloudfront distribution id used to host the binary artifacts",
+      "configuration": {
+        "lambda_env_var_key": "SPM_RELEASE_CLOUDFRONT_DISTRIBUTION_ID"
+      },
+      "destination": {
+        "specifier": "aws-sdk-ios-cci",
+        "mapping_to_destination": [
+          {
+            "destination_key_name": "XCF_RELEASE_DISTRIBUTION_ID"
+          }
+        ]
+      }
+    }
+  ],
+  "destinations": {
+    "aws-sdk-ios-cci": {
+      "type": "cci_env_variable",
+      "description": "Circle CI environment variable for AWS SDK iOS repo",
+      "github_path": "aws-amplify/aws-sdk-ios",
+      "circleci_api_token_secret_id_lambda_env_var_key": "CIRCLE_CI_IOS_SDK_API_TOKEN"
+    },
+    "aws-sdk-ios-spm-cci": {
+      "type": "cci_env_variable",
+      "description": "Circle CI environment variable for AWS SDK iOS SPM repo",
+      "github_path": "aws-amplify/aws-sdk-ios-spm",
+      "circleci_api_token_secret_id_lambda_env_var_key": "CIRCLE_CI_IOS_SDK_SPM_API_TOKEN"
+    }
+  }
+}

--- a/src/release_artifacts_resources/ios/cdk/cdk/credential_rotation/utils/secretmanager_constants.py
+++ b/src/release_artifacts_resources/ios/cdk/cdk/credential_rotation/utils/secretmanager_constants.py
@@ -1,7 +1,12 @@
 # Secrets Manager secret name, whose value is the
 # CircleCI API key used by the Lambda credential rotator
-# to update environment variables.
-CIRCLECI_API_KEY = "CIRCLECI_API_KEY"
+# to update environment variables for aws ios sdk repo.
+CIRCLECI_AWS_IOS_SDK_API_KEY = "CIRCLECI_AWS_IOS_SDK_API_KEY"
+
+# Secrets Manager secret name, whose value is the
+# CircleCI API key used by the Lambda credential rotator
+# to update environment variables for aws ios sdk spm repo.
+CIRCLECI_AWS_IOS_SDK_SPM_API_KEY = "CIRCLECI_AWS_IOS_SDK_SPM_API_KEY"
 
 # Secrets Manager secret name, whose value is a
 # JSON containing the GitHub API token for updating


### PR DESCRIPTION
*Description of changes:*

- Credential rotator now uses the generic json data to retrieve sources and destination
- Changed the STS client to use region
- Bug fixes


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
