### PR TITLE
fix: AWS credential result key in event data

### DIFF
--- a/src/release_artifacts_resources/ios/cdk/cdk/credential_rotation/lambda_functions/src/handler.py
+++ b/src/release_artifacts_resources/ios/cdk/cdk/credential_rotation/lambda_functions/src/handler.py
@@ -120,7 +120,7 @@ def handler(event, context, *, iam=None, sts=None, secretsmanager=None):
     for name, destination_configuration in destinations.items():
 
         destination_type = destination_configuration["type"]
-        mapped_result = destination_values_map[name]
+        mapped_result = destination_values_map.get(name, {})
 
         if destination_type == DestinationType.CIRCLECI_ENVIRONMENT_VARIABLE:
             circleci.update_environment_variables(mapped_result, destination_configuration)

--- a/src/release_artifacts_resources/ios/cdk/cdk/credential_rotation/utils/lambda_event_data.json
+++ b/src/release_artifacts_resources/ios/cdk/cdk/credential_rotation/utils/lambda_event_data.json
@@ -12,15 +12,15 @@
         "mapping_to_destination": [
           {
             "destination_key_name": "XCF_AWS_ACCESS_KEY_ID",
-            "result_value_key": "access_key_id"
+            "result_value_key": "AccessKeyId"
           },
           {
             "destination_key_name": "XCF_AWS_SECRET_ACCESS_KEY",
-            "result_value_key": "secret_access_key"
+            "result_value_key": "SecretAccessKey"
           },
           {
             "destination_key_name": "XCF_AWS_SESSION_TOKEN",
-            "result_value_key": "session_token"
+            "result_value_key": "SessionToken"
           }
         ]
       }


### PR DESCRIPTION
*Description of changes:*
- AWS credential result key in event data
- Return a default empty dictionary if there are no source data for a particular destination


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
