### PR TITLE
fix: Release artifact now takes endpoint for regional sts

### DIFF
--- a/src/release_artifacts_resources/ios/cdk/cdk/credential_rotation/lambda_functions/src/source_data_generator/aws_session_credential_source.py
+++ b/src/release_artifacts_resources/ios/cdk/cdk/credential_rotation/lambda_functions/src/source_data_generator/aws_session_credential_source.py
@@ -78,6 +78,7 @@ def get_session_credentials(
         sts = boto3.client(
             "sts",
             region_name=REGION,
+            endpoint_url=f'https://sts.{REGION}.amazonaws.com',
             aws_access_key_id=credentials[0],
             aws_secret_access_key=credentials[1],
         )


### PR DESCRIPTION
*Description of changes:* Previous PR did not properly updated the regional end point for STS. We have to provide the endpoint to make it work correctly.

Just giving the region in Boto3 will not work - https://github.com/boto/boto3/issues/1859

#### Cloudtrail without this change

```json

{
            "eventVersion": "1.08",
            "userIdentity": {
                "type": "IAMUser",
                "principalId": "xx",
                "arn": "arn:aws:iam::xx:user/CircleCIReleaseProcessIAMUser",
                "accountId": "xx",
                "accessKeyId": "xx",
                "userName": "CircleCIReleaseProcessIAMUser"
            },
            "eventTime": "2021-06-12T01:04:32Z",
            "eventSource": "sts.amazonaws.com",
            "eventName": "AssumeRole",
            "awsRegion": "us-east-1",
            "sourceIPAddress": "xx",
            "userAgent": "xx",
            "requestParameters": {
                "roleArn": "arn:aws:iam::xxx:role/CircleCIReleaseProcessRole",
                "roleSessionName": "CredentialRotationLambda-xx",
                "durationSeconds": 14400
            },
            "responseElements": {
                "credentials": {
                    "accessKeyId": "ASxx",
                    "expiration": "Jun 12, 2021 5:04:32 AM",
                    "sessionToken": "FwoGxx"
                },
                "assumedRoleUser": {
                    "assumedRoleId": "Axx",
                    "arn": "arn:aws:sts::xx:assumed-role/CircleCIReleaseProcessRole/CredentialRotationLambda-xx"
                }
            },
            "requestID": "xxx",
            "eventID": "xx",
            "readOnly": true,
            "resources": [
                {
                    "accountId": "xx",
                    "type": "AWS::IAM::Role",
                    "ARN": "arn:aws:iam::xx:role/CircleCIReleaseProcessRole"
                }
            ],
            "eventType": "AwsApiCall",
            "managementEvent": true,
            "eventCategory": "Management",
            "recipientAccountId": "xx",
            "tlsDetails": {
                "tlsVersion": "TLSv1.2",
                "cipherSuite": "xx",
                "clientProvidedHostHeader": "sts.amazonaws.com"
            }
        }
```
#### Cloudtrail with this change

```json
{
            "eventVersion": "1.08",
            "userIdentity": {
                "type": "IAMUser",
                "principalId": "AIxx",
                "arn": "arn:aws:iam::xx:user/CircleCIReleaseProcessIAMUser",
                "accountId": "xx",
                "accessKeyId": "AKxx",
                "userName": "CircleCIReleaseProcessIAMUser"
            },
            "eventTime": "2021-06-13T21:19:20Z",
            "eventSource": "sts.amazonaws.com",
            "eventName": "AssumeRole",
            "awsRegion": "us-east-1",
            "sourceIPAddress": "xxx",
            "userAgent": "xxx",
            "requestParameters": {
                "roleArn": "arn:aws:iam::xx:role/CircleCIReleaseProcessRole",
                "roleSessionName": "CredentialRotationLambda-xx",
                "durationSeconds": 14400
            },
            "responseElements": {
                "credentials": {
                    "accessKeyId": "ASIxxx",
                    "expiration": "Jun 14, 2021 1:19:20 AM",
                    "sessionToken": "IQoJxxxx"
                },
                "assumedRoleUser": {
                    "assumedRoleId": "ARxx",
                    "arn": "arn:aws:sts::xx:assumed-role/CircleCIReleaseProcessRole/CredentialRotationLambda-xx"
                }
            },
            "requestID": "xx",
            "eventID": "xx",
            "readOnly": true,
            "resources": [
                {
                    "accountId": "xx",
                    "type": "AWS::IAM::Role",
                    "ARN": "arn:aws:iam::xx:role/CircleCIReleaseProcessRole"
                }
            ],
            "eventType": "AwsApiCall",
            "managementEvent": true,
            "eventCategory": "Management",
            "recipientAccountId": "xx",
            "tlsDetails": {
                "tlsVersion": "TLSv1.2",
                "cipherSuite": "xx",
                "clientProvidedHostHeader": "sts.us-east-1.amazonaws.com"
            }
        }
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
