### PR TITLE
chore: bump addressable from 2.7.0 to 2.8.0

### DIFF
--- a/src/fastlane/release_actions/Gemfile.lock
+++ b/src/fastlane/release_actions/Gemfile.lock
@@ -7,7 +7,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (3.0.2)
-    addressable (2.7.0)
+    addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.0)
     atomos (0.1.3)


### PR DESCRIPTION
https://github.com/aws-amplify/amplify-ci-support/security/dependabot


*Description of changes:*
Bump `addressable` from 2.7.0 to 2.8.0 using `bundle update addressable`
Locally verified by running `rake` in `src/fastlane/release_actions`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
