### PR TITLE
fix(npm-token-rotation): make slack webhook config optional in config spec

### DIFF
--- a/src/credentials_rotators/npm-token-rotation/src/lambda/utils/config-schema.ts
+++ b/src/credentials_rotators/npm-token-rotation/src/lambda/utils/config-schema.ts
@@ -89,7 +89,7 @@ export const schema = {
           type: "string",
         },
       },
-      required: ["arn", "publishConfig", "secretKey", "slackWebHookConfig"],
+      required: ["arn", "publishConfig", "secretKey"],
     },
     TokenPublishCircleCIContextConfig: {
       type: "object",


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*
The specification of slack web-hook URL in the config is optional. If not specified, the rotator is implemented such that it skips sending status update in slack channel.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
