### PR TITLE
feat: add lambda for CLI binary integrity monitoring

### DIFF
--- a/src/monitoring_resources/cli_binary_integrity/.gitignore
+++ b/src/monitoring_resources/cli_binary_integrity/.gitignore
@@ -1,0 +1,11 @@
+*.js
+!jest.config.js
+*.d.ts
+node_modules
+
+# CDK asset staging directory
+.cdk.staging
+cdk.out
+
+# config
+config.json

--- a/src/monitoring_resources/cli_binary_integrity/bin/cli-upload-trigger.ts
+++ b/src/monitoring_resources/cli_binary_integrity/bin/cli-upload-trigger.ts
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+import 'source-map-support/register';
+import { App } from 'aws-cdk-lib';
+
+import { CliUploadTriggerStack } from '../lib/cli-upload-trigger';
+
+const app = new App();
+if (!process.env.S3_ACCOUNT_ID || !process.env.S3_ACCOUNT_REGION) {
+   throw new Error('S3_ACCOUNT_ID and S3_ACCOUNT_REGION environment variables must be set.');
+}
+new CliUploadTriggerStack(app, 'CliUploadTriggerStack', {
+   env: { account: process.env.S3_ACCOUNT_ID, region: process.env.S3_ACCOUNT_REGION },
+});

--- a/src/monitoring_resources/cli_binary_integrity/cdk.json
+++ b/src/monitoring_resources/cli_binary_integrity/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "ts-node --prefer-ts-exts bin/cli-upload-trigger.ts"
+}

--- a/src/monitoring_resources/cli_binary_integrity/deploy.sh
+++ b/src/monitoring_resources/cli_binary_integrity/deploy.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+rm -rf cdk.out
+npm run-script build
+npm run-script cdk synth
+npm run-script cdk bootstrap
+npm run-script cdk deploy

--- a/src/monitoring_resources/cli_binary_integrity/lib/cli-upload-trigger.ts
+++ b/src/monitoring_resources/cli_binary_integrity/lib/cli-upload-trigger.ts
@@ -1,0 +1,42 @@
+import { App, Stack, StackProps } from 'aws-cdk-lib';
+import { Bucket, EventType } from 'aws-cdk-lib/aws-s3';
+import { Function, Code, Runtime } from 'aws-cdk-lib/aws-lambda';
+import { S3EventSource } from 'aws-cdk-lib/aws-lambda-event-sources';
+import { PolicyStatement, Policy } from 'aws-cdk-lib/aws-iam';
+
+export class CliUploadTriggerStack extends Stack {
+  constructor(app: App, id: string, props?: StackProps) {
+    super(app, id, props);
+    const bucket = Bucket.fromBucketName(
+      this,
+      'aws-amplify-cli-do-not-delete',
+      'aws-amplify-cli-do-not-delete',
+    );
+
+    const lambdaFunction = new Function(this, 'Function', {
+      code: Code.fromAsset('src'),
+      handler: 'index.handler',
+      functionName: 'BucketPutHandler',
+      runtime: Runtime.NODEJS_14_X,
+    });
+
+    const s3GetObjectPolicy = new PolicyStatement({
+      actions: ['s3:getObject'],
+      resources: [`${bucket.bucketArn}/*`],
+    });
+
+    lambdaFunction.role?.attachInlinePolicy(
+      new Policy(this, 'get-object-policy', {
+        statements: [s3GetObjectPolicy],
+      }),
+    );
+
+    const s3PutEventSource = new S3EventSource(bucket as Bucket, {
+      events: [
+        EventType.OBJECT_CREATED_PUT
+      ]
+    });
+
+    lambdaFunction.addEventSource(s3PutEventSource);
+  }
+}

--- a/src/monitoring_resources/cli_binary_integrity/package-lock.json
+++ b/src/monitoring_resources/cli_binary_integrity/package-lock.json
@@ -1,0 +1,1056 @@
+{
+  "name": "@aws-amplify/monitoring-cli",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@aws-cdk/assets": {
+      "version": "1.154.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/assets/-/assets-1.154.0.tgz",
+      "integrity": "sha512-uN83t0pjeu3T+rRoAOVgE8lV9Uy5ZKD06ax5O3Au1Cam0ZaVymTOqvYnV8e0/7lrFCENWk94311bwHEQMxGr9w==",
+      "requires": {
+        "@aws-cdk/core": "1.154.0",
+        "@aws-cdk/cx-api": "1.154.0",
+        "constructs": "^3.3.69"
+      },
+      "dependencies": {
+        "constructs": {
+          "version": "3.3.283",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.283.tgz",
+          "integrity": "sha512-0LbWDLDPE6sa19F87kTg/a+7ZhO6YXaGs3JYPYcYcd1vzastOUbJQ+GY9O7BweDMLj0Hcw4WP33qV0SFmGnipQ=="
+        }
+      }
+    },
+    "@aws-cdk/aws-acmpca": {
+      "version": "1.154.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-acmpca/-/aws-acmpca-1.154.0.tgz",
+      "integrity": "sha512-RiM7xN8QC5L/H02EN6/rypeWa8P1nnVi6Kjk2iFxmJ70oZ4+X0GKjowwAMxTYVn3T8nyI2GhbqWSWzniD3h4pw==",
+      "requires": {
+        "@aws-cdk/core": "1.154.0",
+        "constructs": "^3.3.69"
+      },
+      "dependencies": {
+        "constructs": {
+          "version": "3.3.283",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.283.tgz",
+          "integrity": "sha512-0LbWDLDPE6sa19F87kTg/a+7ZhO6YXaGs3JYPYcYcd1vzastOUbJQ+GY9O7BweDMLj0Hcw4WP33qV0SFmGnipQ=="
+        }
+      }
+    },
+    "@aws-cdk/aws-apigateway": {
+      "version": "1.154.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigateway/-/aws-apigateway-1.154.0.tgz",
+      "integrity": "sha512-A90I0OZSw7AKTM2fSG83dDwllfYTSocfFalH8w77UlCL06U+cods4+AiWALiBsaTxBzr1UxSQRyY0r2jWOZcjA==",
+      "requires": {
+        "@aws-cdk/aws-certificatemanager": "1.154.0",
+        "@aws-cdk/aws-cloudwatch": "1.154.0",
+        "@aws-cdk/aws-cognito": "1.154.0",
+        "@aws-cdk/aws-ec2": "1.154.0",
+        "@aws-cdk/aws-elasticloadbalancingv2": "1.154.0",
+        "@aws-cdk/aws-iam": "1.154.0",
+        "@aws-cdk/aws-lambda": "1.154.0",
+        "@aws-cdk/aws-logs": "1.154.0",
+        "@aws-cdk/aws-s3": "1.154.0",
+        "@aws-cdk/aws-s3-assets": "1.154.0",
+        "@aws-cdk/aws-stepfunctions": "1.154.0",
+        "@aws-cdk/core": "1.154.0",
+        "@aws-cdk/cx-api": "1.154.0",
+        "constructs": "^3.3.69"
+      },
+      "dependencies": {
+        "constructs": {
+          "version": "3.3.283",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.283.tgz",
+          "integrity": "sha512-0LbWDLDPE6sa19F87kTg/a+7ZhO6YXaGs3JYPYcYcd1vzastOUbJQ+GY9O7BweDMLj0Hcw4WP33qV0SFmGnipQ=="
+        }
+      }
+    },
+    "@aws-cdk/aws-applicationautoscaling": {
+      "version": "1.154.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-applicationautoscaling/-/aws-applicationautoscaling-1.154.0.tgz",
+      "integrity": "sha512-dIO8yx9DIigt2E8B4xnrPoKpmEky7ueqcPJX26bNsq+tuqgAw7w39pU5pXj0kLvDKWn07h8L+BdWaANTnqtGOw==",
+      "requires": {
+        "@aws-cdk/aws-autoscaling-common": "1.154.0",
+        "@aws-cdk/aws-cloudwatch": "1.154.0",
+        "@aws-cdk/aws-iam": "1.154.0",
+        "@aws-cdk/core": "1.154.0",
+        "constructs": "^3.3.69"
+      },
+      "dependencies": {
+        "constructs": {
+          "version": "3.3.283",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.283.tgz",
+          "integrity": "sha512-0LbWDLDPE6sa19F87kTg/a+7ZhO6YXaGs3JYPYcYcd1vzastOUbJQ+GY9O7BweDMLj0Hcw4WP33qV0SFmGnipQ=="
+        }
+      }
+    },
+    "@aws-cdk/aws-autoscaling-common": {
+      "version": "1.154.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling-common/-/aws-autoscaling-common-1.154.0.tgz",
+      "integrity": "sha512-X/HyXyOEuRppmO3yeX9HBo6T+bs8kFt4T/6yS18Aej9ZWHI7KGgC5xjX6dgVWaCwbrGuddRJnSzjUMaXl6qJgg==",
+      "requires": {
+        "@aws-cdk/aws-iam": "1.154.0",
+        "@aws-cdk/core": "1.154.0",
+        "constructs": "^3.3.69"
+      },
+      "dependencies": {
+        "constructs": {
+          "version": "3.3.283",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.283.tgz",
+          "integrity": "sha512-0LbWDLDPE6sa19F87kTg/a+7ZhO6YXaGs3JYPYcYcd1vzastOUbJQ+GY9O7BweDMLj0Hcw4WP33qV0SFmGnipQ=="
+        }
+      }
+    },
+    "@aws-cdk/aws-certificatemanager": {
+      "version": "1.154.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-certificatemanager/-/aws-certificatemanager-1.154.0.tgz",
+      "integrity": "sha512-MbRq09O/01lHc+CSJ6uPugmbqf5hUQkI5/wUeOQctG2wQ2EtAPWgNpNif62tDYm9bApP8PEf5jS7FgEKsvh5oQ==",
+      "requires": {
+        "@aws-cdk/aws-acmpca": "1.154.0",
+        "@aws-cdk/aws-cloudwatch": "1.154.0",
+        "@aws-cdk/aws-iam": "1.154.0",
+        "@aws-cdk/aws-lambda": "1.154.0",
+        "@aws-cdk/aws-route53": "1.154.0",
+        "@aws-cdk/core": "1.154.0",
+        "constructs": "^3.3.69"
+      },
+      "dependencies": {
+        "constructs": {
+          "version": "3.3.283",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.283.tgz",
+          "integrity": "sha512-0LbWDLDPE6sa19F87kTg/a+7ZhO6YXaGs3JYPYcYcd1vzastOUbJQ+GY9O7BweDMLj0Hcw4WP33qV0SFmGnipQ=="
+        }
+      }
+    },
+    "@aws-cdk/aws-cloudformation": {
+      "version": "1.154.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudformation/-/aws-cloudformation-1.154.0.tgz",
+      "integrity": "sha512-21PyUyiq8KT2qhVDY1+BCZWhioa9u6IPjkA7elKe4pLLahXNEbiGEMtVctyUqF9VjymN1pOVIkyAEyLA8PhS2g==",
+      "requires": {
+        "@aws-cdk/aws-iam": "1.154.0",
+        "@aws-cdk/aws-lambda": "1.154.0",
+        "@aws-cdk/aws-s3": "1.154.0",
+        "@aws-cdk/aws-sns": "1.154.0",
+        "@aws-cdk/core": "1.154.0",
+        "@aws-cdk/cx-api": "1.154.0",
+        "constructs": "^3.3.69"
+      },
+      "dependencies": {
+        "constructs": {
+          "version": "3.3.283",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.283.tgz",
+          "integrity": "sha512-0LbWDLDPE6sa19F87kTg/a+7ZhO6YXaGs3JYPYcYcd1vzastOUbJQ+GY9O7BweDMLj0Hcw4WP33qV0SFmGnipQ=="
+        }
+      }
+    },
+    "@aws-cdk/aws-cloudwatch": {
+      "version": "1.154.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-1.154.0.tgz",
+      "integrity": "sha512-WF4tVSTd9aF1CQPaAUhwoJb/mjb1gVnGfk90yRr2aBax0jc5kYkiDn2lQGXNfUVpTI0T0o4fNtDTYriq3O8fgQ==",
+      "requires": {
+        "@aws-cdk/aws-iam": "1.154.0",
+        "@aws-cdk/core": "1.154.0",
+        "constructs": "^3.3.69"
+      },
+      "dependencies": {
+        "constructs": {
+          "version": "3.3.283",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.283.tgz",
+          "integrity": "sha512-0LbWDLDPE6sa19F87kTg/a+7ZhO6YXaGs3JYPYcYcd1vzastOUbJQ+GY9O7BweDMLj0Hcw4WP33qV0SFmGnipQ=="
+        }
+      }
+    },
+    "@aws-cdk/aws-codeguruprofiler": {
+      "version": "1.154.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codeguruprofiler/-/aws-codeguruprofiler-1.154.0.tgz",
+      "integrity": "sha512-EJR7HbQDnxQFz3KOuq0Zg5wgLPxlJ+I9b4Tfi7F3I8U3+VQj8hBVYQAFG3q3M2qlCO4ZDdinZE/BdCdBI3elMA==",
+      "requires": {
+        "@aws-cdk/aws-iam": "1.154.0",
+        "@aws-cdk/core": "1.154.0",
+        "constructs": "^3.3.69"
+      },
+      "dependencies": {
+        "constructs": {
+          "version": "3.3.283",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.283.tgz",
+          "integrity": "sha512-0LbWDLDPE6sa19F87kTg/a+7ZhO6YXaGs3JYPYcYcd1vzastOUbJQ+GY9O7BweDMLj0Hcw4WP33qV0SFmGnipQ=="
+        }
+      }
+    },
+    "@aws-cdk/aws-codestarnotifications": {
+      "version": "1.154.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codestarnotifications/-/aws-codestarnotifications-1.154.0.tgz",
+      "integrity": "sha512-HbsYxnzF2rsf9hu2CUrk4q4nr3MqYWNkcfyoSH4giQGqafMOhcNE67T6ZHLzMaCgfDVUoZWTNQbm92RgQ7lsig==",
+      "requires": {
+        "@aws-cdk/core": "1.154.0",
+        "constructs": "^3.3.69"
+      },
+      "dependencies": {
+        "constructs": {
+          "version": "3.3.283",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.283.tgz",
+          "integrity": "sha512-0LbWDLDPE6sa19F87kTg/a+7ZhO6YXaGs3JYPYcYcd1vzastOUbJQ+GY9O7BweDMLj0Hcw4WP33qV0SFmGnipQ=="
+        }
+      }
+    },
+    "@aws-cdk/aws-cognito": {
+      "version": "1.154.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cognito/-/aws-cognito-1.154.0.tgz",
+      "integrity": "sha512-1DU9bKFE7ubWe9AeCuzSHesq+UHM1n9Lz8upxAkNfcbpKiclqhV7e1c5yJNzkfsAxMoMk0svbQm934L9+hySVw==",
+      "requires": {
+        "@aws-cdk/aws-certificatemanager": "1.154.0",
+        "@aws-cdk/aws-iam": "1.154.0",
+        "@aws-cdk/aws-kms": "1.154.0",
+        "@aws-cdk/aws-lambda": "1.154.0",
+        "@aws-cdk/core": "1.154.0",
+        "@aws-cdk/custom-resources": "1.154.0",
+        "constructs": "^3.3.69",
+        "punycode": "^2.1.1"
+      },
+      "dependencies": {
+        "constructs": {
+          "version": "3.3.283",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.283.tgz",
+          "integrity": "sha512-0LbWDLDPE6sa19F87kTg/a+7ZhO6YXaGs3JYPYcYcd1vzastOUbJQ+GY9O7BweDMLj0Hcw4WP33qV0SFmGnipQ=="
+        },
+        "punycode": {
+          "version": "2.1.1",
+          "bundled": true
+        }
+      }
+    },
+    "@aws-cdk/aws-dynamodb": {
+      "version": "1.154.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-dynamodb/-/aws-dynamodb-1.154.0.tgz",
+      "integrity": "sha512-NoS8/80A22ddshkJS5MmpBkUmTcnbNjkxVearCeFkkf0tA+XAwLsR7tNXJJDLkkVjgmn1K+UcV1lzK07uG19QA==",
+      "requires": {
+        "@aws-cdk/aws-applicationautoscaling": "1.154.0",
+        "@aws-cdk/aws-cloudwatch": "1.154.0",
+        "@aws-cdk/aws-iam": "1.154.0",
+        "@aws-cdk/aws-kinesis": "1.154.0",
+        "@aws-cdk/aws-kms": "1.154.0",
+        "@aws-cdk/aws-lambda": "1.154.0",
+        "@aws-cdk/core": "1.154.0",
+        "@aws-cdk/custom-resources": "1.154.0",
+        "constructs": "^3.3.69"
+      },
+      "dependencies": {
+        "constructs": {
+          "version": "3.3.283",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.283.tgz",
+          "integrity": "sha512-0LbWDLDPE6sa19F87kTg/a+7ZhO6YXaGs3JYPYcYcd1vzastOUbJQ+GY9O7BweDMLj0Hcw4WP33qV0SFmGnipQ=="
+        }
+      }
+    },
+    "@aws-cdk/aws-ec2": {
+      "version": "1.154.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ec2/-/aws-ec2-1.154.0.tgz",
+      "integrity": "sha512-LDbS9D2CoRP6iFReWamRCzU//C3VI9NbPZoaaRcyIk0/KhKhAUUIN0GAPvHKbzRfW0oEuREkszM+xCXxST+1sA==",
+      "requires": {
+        "@aws-cdk/aws-cloudwatch": "1.154.0",
+        "@aws-cdk/aws-iam": "1.154.0",
+        "@aws-cdk/aws-kms": "1.154.0",
+        "@aws-cdk/aws-logs": "1.154.0",
+        "@aws-cdk/aws-s3": "1.154.0",
+        "@aws-cdk/aws-s3-assets": "1.154.0",
+        "@aws-cdk/aws-ssm": "1.154.0",
+        "@aws-cdk/cloud-assembly-schema": "1.154.0",
+        "@aws-cdk/core": "1.154.0",
+        "@aws-cdk/cx-api": "1.154.0",
+        "@aws-cdk/region-info": "1.154.0",
+        "constructs": "^3.3.69"
+      },
+      "dependencies": {
+        "constructs": {
+          "version": "3.3.283",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.283.tgz",
+          "integrity": "sha512-0LbWDLDPE6sa19F87kTg/a+7ZhO6YXaGs3JYPYcYcd1vzastOUbJQ+GY9O7BweDMLj0Hcw4WP33qV0SFmGnipQ=="
+        }
+      }
+    },
+    "@aws-cdk/aws-ecr": {
+      "version": "1.154.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecr/-/aws-ecr-1.154.0.tgz",
+      "integrity": "sha512-o+L7pTr4dsT/Uj2ifXSaUZsTowdMc8AbFwJvfWdhHw5R4agOV8o6oFOzXuCnhu53NuY917F4TEaQEkjWprwq1Q==",
+      "requires": {
+        "@aws-cdk/aws-events": "1.154.0",
+        "@aws-cdk/aws-iam": "1.154.0",
+        "@aws-cdk/aws-kms": "1.154.0",
+        "@aws-cdk/core": "1.154.0",
+        "constructs": "^3.3.69"
+      },
+      "dependencies": {
+        "constructs": {
+          "version": "3.3.283",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.283.tgz",
+          "integrity": "sha512-0LbWDLDPE6sa19F87kTg/a+7ZhO6YXaGs3JYPYcYcd1vzastOUbJQ+GY9O7BweDMLj0Hcw4WP33qV0SFmGnipQ=="
+        }
+      }
+    },
+    "@aws-cdk/aws-ecr-assets": {
+      "version": "1.154.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecr-assets/-/aws-ecr-assets-1.154.0.tgz",
+      "integrity": "sha512-nvaOMEBFj14/sS+LvItiiXY4JzvIyTNa29sZ44+bZa4q4Tn0J6RT57clkJ6XrMWMA7ul27E09BiYDPuTTiuhLA==",
+      "requires": {
+        "@aws-cdk/assets": "1.154.0",
+        "@aws-cdk/aws-ecr": "1.154.0",
+        "@aws-cdk/aws-iam": "1.154.0",
+        "@aws-cdk/aws-s3": "1.154.0",
+        "@aws-cdk/core": "1.154.0",
+        "@aws-cdk/cx-api": "1.154.0",
+        "constructs": "^3.3.69"
+      },
+      "dependencies": {
+        "constructs": {
+          "version": "3.3.283",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.283.tgz",
+          "integrity": "sha512-0LbWDLDPE6sa19F87kTg/a+7ZhO6YXaGs3JYPYcYcd1vzastOUbJQ+GY9O7BweDMLj0Hcw4WP33qV0SFmGnipQ=="
+        }
+      }
+    },
+    "@aws-cdk/aws-efs": {
+      "version": "1.154.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-efs/-/aws-efs-1.154.0.tgz",
+      "integrity": "sha512-Gjmi7QzBYiCjidBC6ONgnCNdVR+f4s9VNR+YgNTHpMGugqwAQzXVpBUwopt7dG0ePmSCH13S6FXwhh7JJ23aaw==",
+      "requires": {
+        "@aws-cdk/aws-ec2": "1.154.0",
+        "@aws-cdk/aws-iam": "1.154.0",
+        "@aws-cdk/aws-kms": "1.154.0",
+        "@aws-cdk/cloud-assembly-schema": "1.154.0",
+        "@aws-cdk/core": "1.154.0",
+        "@aws-cdk/cx-api": "1.154.0",
+        "constructs": "^3.3.69"
+      },
+      "dependencies": {
+        "constructs": {
+          "version": "3.3.283",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.283.tgz",
+          "integrity": "sha512-0LbWDLDPE6sa19F87kTg/a+7ZhO6YXaGs3JYPYcYcd1vzastOUbJQ+GY9O7BweDMLj0Hcw4WP33qV0SFmGnipQ=="
+        }
+      }
+    },
+    "@aws-cdk/aws-elasticloadbalancingv2": {
+      "version": "1.154.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-elasticloadbalancingv2/-/aws-elasticloadbalancingv2-1.154.0.tgz",
+      "integrity": "sha512-wXHwseCfuaJRTkFErhwubJink3gKwh0h7WG9i1nSqwiUR8ouITqEGFZrFIWylxMlxZam/jnjrVlBzBqZLygrBg==",
+      "requires": {
+        "@aws-cdk/aws-certificatemanager": "1.154.0",
+        "@aws-cdk/aws-cloudwatch": "1.154.0",
+        "@aws-cdk/aws-ec2": "1.154.0",
+        "@aws-cdk/aws-iam": "1.154.0",
+        "@aws-cdk/aws-lambda": "1.154.0",
+        "@aws-cdk/aws-route53": "1.154.0",
+        "@aws-cdk/aws-s3": "1.154.0",
+        "@aws-cdk/cloud-assembly-schema": "1.154.0",
+        "@aws-cdk/core": "1.154.0",
+        "@aws-cdk/cx-api": "1.154.0",
+        "@aws-cdk/region-info": "1.154.0",
+        "constructs": "^3.3.69"
+      },
+      "dependencies": {
+        "constructs": {
+          "version": "3.3.283",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.283.tgz",
+          "integrity": "sha512-0LbWDLDPE6sa19F87kTg/a+7ZhO6YXaGs3JYPYcYcd1vzastOUbJQ+GY9O7BweDMLj0Hcw4WP33qV0SFmGnipQ=="
+        }
+      }
+    },
+    "@aws-cdk/aws-events": {
+      "version": "1.154.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-events/-/aws-events-1.154.0.tgz",
+      "integrity": "sha512-/1nMFvmed4erpTezRay/APmaK5pFJXaqmSSJ7qI2ktKuvEtxI1JU2a1v+XPgkt9g35nOTr4gJgg1ZH7Vzdx9Dg==",
+      "requires": {
+        "@aws-cdk/aws-iam": "1.154.0",
+        "@aws-cdk/core": "1.154.0",
+        "constructs": "^3.3.69"
+      },
+      "dependencies": {
+        "constructs": {
+          "version": "3.3.283",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.283.tgz",
+          "integrity": "sha512-0LbWDLDPE6sa19F87kTg/a+7ZhO6YXaGs3JYPYcYcd1vzastOUbJQ+GY9O7BweDMLj0Hcw4WP33qV0SFmGnipQ=="
+        }
+      }
+    },
+    "@aws-cdk/aws-iam": {
+      "version": "1.154.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-iam/-/aws-iam-1.154.0.tgz",
+      "integrity": "sha512-BcfxhZV4HoxGNQ2mj3T2zm0BKdG/LOCgAHPqN6U8A2r1Yb06ZCA3Mz8ALncVkNyz0ESw7r0oUNdXuDtwSd7Z8w==",
+      "requires": {
+        "@aws-cdk/core": "1.154.0",
+        "@aws-cdk/cx-api": "1.154.0",
+        "@aws-cdk/region-info": "1.154.0",
+        "constructs": "^3.3.69"
+      },
+      "dependencies": {
+        "constructs": {
+          "version": "3.3.283",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.283.tgz",
+          "integrity": "sha512-0LbWDLDPE6sa19F87kTg/a+7ZhO6YXaGs3JYPYcYcd1vzastOUbJQ+GY9O7BweDMLj0Hcw4WP33qV0SFmGnipQ=="
+        }
+      }
+    },
+    "@aws-cdk/aws-kinesis": {
+      "version": "1.154.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-kinesis/-/aws-kinesis-1.154.0.tgz",
+      "integrity": "sha512-wFlJMQgAplP1cvee8EW6CPY0A9V0pt0sFJgL+2OlOZcZM5ZNbGEQMZ9MAZ6vF6zH3PYjdRKAzQt/55wZiuot7w==",
+      "requires": {
+        "@aws-cdk/aws-cloudwatch": "1.154.0",
+        "@aws-cdk/aws-iam": "1.154.0",
+        "@aws-cdk/aws-kms": "1.154.0",
+        "@aws-cdk/aws-logs": "1.154.0",
+        "@aws-cdk/core": "1.154.0",
+        "constructs": "^3.3.69"
+      },
+      "dependencies": {
+        "constructs": {
+          "version": "3.3.283",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.283.tgz",
+          "integrity": "sha512-0LbWDLDPE6sa19F87kTg/a+7ZhO6YXaGs3JYPYcYcd1vzastOUbJQ+GY9O7BweDMLj0Hcw4WP33qV0SFmGnipQ=="
+        }
+      }
+    },
+    "@aws-cdk/aws-kms": {
+      "version": "1.154.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-kms/-/aws-kms-1.154.0.tgz",
+      "integrity": "sha512-mJcmeUKQe9GsOxtzJNb0Wf8X6t8N4v0fS26Jzr7dcL/gxvH3QnxecPEXnAr8htj2tht3eTO1bXfHyhQLSPDXPA==",
+      "requires": {
+        "@aws-cdk/aws-iam": "1.154.0",
+        "@aws-cdk/cloud-assembly-schema": "1.154.0",
+        "@aws-cdk/core": "1.154.0",
+        "@aws-cdk/cx-api": "1.154.0",
+        "constructs": "^3.3.69"
+      },
+      "dependencies": {
+        "constructs": {
+          "version": "3.3.283",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.283.tgz",
+          "integrity": "sha512-0LbWDLDPE6sa19F87kTg/a+7ZhO6YXaGs3JYPYcYcd1vzastOUbJQ+GY9O7BweDMLj0Hcw4WP33qV0SFmGnipQ=="
+        }
+      }
+    },
+    "@aws-cdk/aws-lambda": {
+      "version": "1.154.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda/-/aws-lambda-1.154.0.tgz",
+      "integrity": "sha512-W3vLl1VmIIxHQ/pYQ52169RiYP67bz2GTcGiC10TLXzx1PtA5Ylzff9gA+qKC2o6tFaQySoATr/C9adlQmUAcw==",
+      "requires": {
+        "@aws-cdk/aws-applicationautoscaling": "1.154.0",
+        "@aws-cdk/aws-cloudwatch": "1.154.0",
+        "@aws-cdk/aws-codeguruprofiler": "1.154.0",
+        "@aws-cdk/aws-ec2": "1.154.0",
+        "@aws-cdk/aws-ecr": "1.154.0",
+        "@aws-cdk/aws-ecr-assets": "1.154.0",
+        "@aws-cdk/aws-efs": "1.154.0",
+        "@aws-cdk/aws-events": "1.154.0",
+        "@aws-cdk/aws-iam": "1.154.0",
+        "@aws-cdk/aws-kms": "1.154.0",
+        "@aws-cdk/aws-logs": "1.154.0",
+        "@aws-cdk/aws-s3": "1.154.0",
+        "@aws-cdk/aws-s3-assets": "1.154.0",
+        "@aws-cdk/aws-signer": "1.154.0",
+        "@aws-cdk/aws-sns": "1.154.0",
+        "@aws-cdk/aws-sqs": "1.154.0",
+        "@aws-cdk/core": "1.154.0",
+        "@aws-cdk/cx-api": "1.154.0",
+        "@aws-cdk/region-info": "1.154.0",
+        "constructs": "^3.3.69"
+      },
+      "dependencies": {
+        "constructs": {
+          "version": "3.3.283",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.283.tgz",
+          "integrity": "sha512-0LbWDLDPE6sa19F87kTg/a+7ZhO6YXaGs3JYPYcYcd1vzastOUbJQ+GY9O7BweDMLj0Hcw4WP33qV0SFmGnipQ=="
+        }
+      }
+    },
+    "@aws-cdk/aws-lambda-event-sources": {
+      "version": "1.154.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda-event-sources/-/aws-lambda-event-sources-1.154.0.tgz",
+      "integrity": "sha512-aBr9pxpsh6Js/nB4vo5PLTA+O3Ht9X6qAp6C8Bys+ArXV0hZR9kTLhi11tw6mrqiZc8lZVTPfFaMyhti5h560g==",
+      "requires": {
+        "@aws-cdk/aws-apigateway": "1.154.0",
+        "@aws-cdk/aws-dynamodb": "1.154.0",
+        "@aws-cdk/aws-ec2": "1.154.0",
+        "@aws-cdk/aws-events": "1.154.0",
+        "@aws-cdk/aws-iam": "1.154.0",
+        "@aws-cdk/aws-kinesis": "1.154.0",
+        "@aws-cdk/aws-lambda": "1.154.0",
+        "@aws-cdk/aws-s3": "1.154.0",
+        "@aws-cdk/aws-s3-notifications": "1.154.0",
+        "@aws-cdk/aws-secretsmanager": "1.154.0",
+        "@aws-cdk/aws-sns": "1.154.0",
+        "@aws-cdk/aws-sns-subscriptions": "1.154.0",
+        "@aws-cdk/aws-sqs": "1.154.0",
+        "@aws-cdk/core": "1.154.0",
+        "constructs": "^3.3.69"
+      },
+      "dependencies": {
+        "constructs": {
+          "version": "3.3.283",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.283.tgz",
+          "integrity": "sha512-0LbWDLDPE6sa19F87kTg/a+7ZhO6YXaGs3JYPYcYcd1vzastOUbJQ+GY9O7BweDMLj0Hcw4WP33qV0SFmGnipQ=="
+        }
+      }
+    },
+    "@aws-cdk/aws-logs": {
+      "version": "1.154.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-logs/-/aws-logs-1.154.0.tgz",
+      "integrity": "sha512-XvaEeApdjVSxNcxANUaddJxXfAZ5MsWyvEZkxfdSt2lfafgrSB7mfSligY4za71KgLp0CvmWTIzfD7B3UZg9yw==",
+      "requires": {
+        "@aws-cdk/aws-cloudwatch": "1.154.0",
+        "@aws-cdk/aws-iam": "1.154.0",
+        "@aws-cdk/aws-kms": "1.154.0",
+        "@aws-cdk/aws-s3-assets": "1.154.0",
+        "@aws-cdk/core": "1.154.0",
+        "@aws-cdk/cx-api": "1.154.0",
+        "constructs": "^3.3.69"
+      },
+      "dependencies": {
+        "constructs": {
+          "version": "3.3.283",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.283.tgz",
+          "integrity": "sha512-0LbWDLDPE6sa19F87kTg/a+7ZhO6YXaGs3JYPYcYcd1vzastOUbJQ+GY9O7BweDMLj0Hcw4WP33qV0SFmGnipQ=="
+        }
+      }
+    },
+    "@aws-cdk/aws-route53": {
+      "version": "1.154.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-route53/-/aws-route53-1.154.0.tgz",
+      "integrity": "sha512-RhfCTMUJVWh4J2H4qeJnZIkUKVofRSmCA/5xqildJ1eTi6gYsu5+p++erTHNwIDZlzpQqUjMeavK4lE7s2xwew==",
+      "requires": {
+        "@aws-cdk/aws-ec2": "1.154.0",
+        "@aws-cdk/aws-iam": "1.154.0",
+        "@aws-cdk/aws-logs": "1.154.0",
+        "@aws-cdk/cloud-assembly-schema": "1.154.0",
+        "@aws-cdk/core": "1.154.0",
+        "@aws-cdk/custom-resources": "1.154.0",
+        "constructs": "^3.3.69"
+      },
+      "dependencies": {
+        "constructs": {
+          "version": "3.3.283",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.283.tgz",
+          "integrity": "sha512-0LbWDLDPE6sa19F87kTg/a+7ZhO6YXaGs3JYPYcYcd1vzastOUbJQ+GY9O7BweDMLj0Hcw4WP33qV0SFmGnipQ=="
+        }
+      }
+    },
+    "@aws-cdk/aws-s3": {
+      "version": "1.154.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3/-/aws-s3-1.154.0.tgz",
+      "integrity": "sha512-XJJPJ+pF5ARXlZcEQeiZbkBvtT3+t3YNKLBLa7oZrYmrpMYN7pEPiK6nSu5XCBImGS8khzqFBOXQyl1KYmVyMw==",
+      "requires": {
+        "@aws-cdk/aws-events": "1.154.0",
+        "@aws-cdk/aws-iam": "1.154.0",
+        "@aws-cdk/aws-kms": "1.154.0",
+        "@aws-cdk/core": "1.154.0",
+        "@aws-cdk/cx-api": "1.154.0",
+        "constructs": "^3.3.69"
+      },
+      "dependencies": {
+        "constructs": {
+          "version": "3.3.283",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.283.tgz",
+          "integrity": "sha512-0LbWDLDPE6sa19F87kTg/a+7ZhO6YXaGs3JYPYcYcd1vzastOUbJQ+GY9O7BweDMLj0Hcw4WP33qV0SFmGnipQ=="
+        }
+      }
+    },
+    "@aws-cdk/aws-s3-assets": {
+      "version": "1.154.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3-assets/-/aws-s3-assets-1.154.0.tgz",
+      "integrity": "sha512-Na+zvrzOax1OOgULXDs4mdwD7IV8k9a9CEu5SRT9RnOLFQxRTMiiavjagbWCwx2n6664hWlBYl53T8civJFS+g==",
+      "requires": {
+        "@aws-cdk/assets": "1.154.0",
+        "@aws-cdk/aws-iam": "1.154.0",
+        "@aws-cdk/aws-kms": "1.154.0",
+        "@aws-cdk/aws-s3": "1.154.0",
+        "@aws-cdk/core": "1.154.0",
+        "@aws-cdk/cx-api": "1.154.0",
+        "constructs": "^3.3.69"
+      },
+      "dependencies": {
+        "constructs": {
+          "version": "3.3.283",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.283.tgz",
+          "integrity": "sha512-0LbWDLDPE6sa19F87kTg/a+7ZhO6YXaGs3JYPYcYcd1vzastOUbJQ+GY9O7BweDMLj0Hcw4WP33qV0SFmGnipQ=="
+        }
+      }
+    },
+    "@aws-cdk/aws-s3-notifications": {
+      "version": "1.154.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3-notifications/-/aws-s3-notifications-1.154.0.tgz",
+      "integrity": "sha512-Vw+zw3wg/+lIabzVs3QkNFh2Kur2LrGay/QID2E9us6JlAxye8nEqDibCnrfHV9NMwj+OH4q7PSP8xVwzwHX2Q==",
+      "requires": {
+        "@aws-cdk/aws-iam": "1.154.0",
+        "@aws-cdk/aws-kms": "1.154.0",
+        "@aws-cdk/aws-lambda": "1.154.0",
+        "@aws-cdk/aws-s3": "1.154.0",
+        "@aws-cdk/aws-sns": "1.154.0",
+        "@aws-cdk/aws-sqs": "1.154.0",
+        "@aws-cdk/core": "1.154.0",
+        "constructs": "^3.3.69"
+      },
+      "dependencies": {
+        "constructs": {
+          "version": "3.3.283",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.283.tgz",
+          "integrity": "sha512-0LbWDLDPE6sa19F87kTg/a+7ZhO6YXaGs3JYPYcYcd1vzastOUbJQ+GY9O7BweDMLj0Hcw4WP33qV0SFmGnipQ=="
+        }
+      }
+    },
+    "@aws-cdk/aws-sam": {
+      "version": "1.154.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sam/-/aws-sam-1.154.0.tgz",
+      "integrity": "sha512-dObTU38QK+Tc98hFvjW9Reiy4NjDHhBf5KpN0HtRHWkiGuQrtZVpxcEA71uy6gT0skvfJxuIKv6qVO3Yh//o1g==",
+      "requires": {
+        "@aws-cdk/core": "1.154.0",
+        "constructs": "^3.3.69"
+      },
+      "dependencies": {
+        "constructs": {
+          "version": "3.3.283",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.283.tgz",
+          "integrity": "sha512-0LbWDLDPE6sa19F87kTg/a+7ZhO6YXaGs3JYPYcYcd1vzastOUbJQ+GY9O7BweDMLj0Hcw4WP33qV0SFmGnipQ=="
+        }
+      }
+    },
+    "@aws-cdk/aws-secretsmanager": {
+      "version": "1.154.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-secretsmanager/-/aws-secretsmanager-1.154.0.tgz",
+      "integrity": "sha512-xhL0I6ghv3GEuFKDRRLz8uhB3yyvhgyunHcjk1ovyZ7bJrNHErN35qLmk+HPCHJjmAcIaRWWFuwCF3OMCKKDeg==",
+      "requires": {
+        "@aws-cdk/aws-ec2": "1.154.0",
+        "@aws-cdk/aws-iam": "1.154.0",
+        "@aws-cdk/aws-kms": "1.154.0",
+        "@aws-cdk/aws-lambda": "1.154.0",
+        "@aws-cdk/aws-sam": "1.154.0",
+        "@aws-cdk/core": "1.154.0",
+        "@aws-cdk/cx-api": "1.154.0",
+        "constructs": "^3.3.69"
+      },
+      "dependencies": {
+        "constructs": {
+          "version": "3.3.283",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.283.tgz",
+          "integrity": "sha512-0LbWDLDPE6sa19F87kTg/a+7ZhO6YXaGs3JYPYcYcd1vzastOUbJQ+GY9O7BweDMLj0Hcw4WP33qV0SFmGnipQ=="
+        }
+      }
+    },
+    "@aws-cdk/aws-signer": {
+      "version": "1.154.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-signer/-/aws-signer-1.154.0.tgz",
+      "integrity": "sha512-wNvrnIVlmbZjaGc619caIZr/c7haAqoMV3xyET1SEktHbyCoscPmHwUX6IASCStTtgr5jUO+7CdWhpGrECEprA==",
+      "requires": {
+        "@aws-cdk/core": "1.154.0",
+        "constructs": "^3.3.69"
+      },
+      "dependencies": {
+        "constructs": {
+          "version": "3.3.283",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.283.tgz",
+          "integrity": "sha512-0LbWDLDPE6sa19F87kTg/a+7ZhO6YXaGs3JYPYcYcd1vzastOUbJQ+GY9O7BweDMLj0Hcw4WP33qV0SFmGnipQ=="
+        }
+      }
+    },
+    "@aws-cdk/aws-sns": {
+      "version": "1.154.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sns/-/aws-sns-1.154.0.tgz",
+      "integrity": "sha512-MvVowqLInyeDx0j/VS3FKQ5yosm0da+dppcQvQIwe/NYm3+l7qyGlDQw2TmFYdKYmA1WLPQPvmpTqaMbtZwn4g==",
+      "requires": {
+        "@aws-cdk/aws-cloudwatch": "1.154.0",
+        "@aws-cdk/aws-codestarnotifications": "1.154.0",
+        "@aws-cdk/aws-events": "1.154.0",
+        "@aws-cdk/aws-iam": "1.154.0",
+        "@aws-cdk/aws-kms": "1.154.0",
+        "@aws-cdk/aws-sqs": "1.154.0",
+        "@aws-cdk/core": "1.154.0",
+        "constructs": "^3.3.69"
+      },
+      "dependencies": {
+        "constructs": {
+          "version": "3.3.283",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.283.tgz",
+          "integrity": "sha512-0LbWDLDPE6sa19F87kTg/a+7ZhO6YXaGs3JYPYcYcd1vzastOUbJQ+GY9O7BweDMLj0Hcw4WP33qV0SFmGnipQ=="
+        }
+      }
+    },
+    "@aws-cdk/aws-sns-subscriptions": {
+      "version": "1.154.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sns-subscriptions/-/aws-sns-subscriptions-1.154.0.tgz",
+      "integrity": "sha512-TmqvTjj/HHT7iQ/NjFZjlKW/jKRpo2F19xt3S8f+kP0RG2bYZmwWiOGgacquqUCK9UrVD5BTqcYEvdwAjG0L1w==",
+      "requires": {
+        "@aws-cdk/aws-iam": "1.154.0",
+        "@aws-cdk/aws-kms": "1.154.0",
+        "@aws-cdk/aws-lambda": "1.154.0",
+        "@aws-cdk/aws-sns": "1.154.0",
+        "@aws-cdk/aws-sqs": "1.154.0",
+        "@aws-cdk/core": "1.154.0",
+        "constructs": "^3.3.69"
+      },
+      "dependencies": {
+        "constructs": {
+          "version": "3.3.283",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.283.tgz",
+          "integrity": "sha512-0LbWDLDPE6sa19F87kTg/a+7ZhO6YXaGs3JYPYcYcd1vzastOUbJQ+GY9O7BweDMLj0Hcw4WP33qV0SFmGnipQ=="
+        }
+      }
+    },
+    "@aws-cdk/aws-sqs": {
+      "version": "1.154.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sqs/-/aws-sqs-1.154.0.tgz",
+      "integrity": "sha512-p+S8O+Qq4XnDf7iSl2iYVUehxO33nWlfOUFqrDw039/qwjMH0GEKNfZyRR8nYqOz8KvEsWKUfZFLVg7bwgQtnw==",
+      "requires": {
+        "@aws-cdk/aws-cloudwatch": "1.154.0",
+        "@aws-cdk/aws-iam": "1.154.0",
+        "@aws-cdk/aws-kms": "1.154.0",
+        "@aws-cdk/core": "1.154.0",
+        "constructs": "^3.3.69"
+      },
+      "dependencies": {
+        "constructs": {
+          "version": "3.3.283",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.283.tgz",
+          "integrity": "sha512-0LbWDLDPE6sa19F87kTg/a+7ZhO6YXaGs3JYPYcYcd1vzastOUbJQ+GY9O7BweDMLj0Hcw4WP33qV0SFmGnipQ=="
+        }
+      }
+    },
+    "@aws-cdk/aws-ssm": {
+      "version": "1.154.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ssm/-/aws-ssm-1.154.0.tgz",
+      "integrity": "sha512-hgW2cMZRGBneJaPPwUFV93Ohqe9lfpbqo3nQkzngiYYzjpPCO16E3dgsaC/o9jluRD/82qRiBSakegNhtzjbAw==",
+      "requires": {
+        "@aws-cdk/aws-iam": "1.154.0",
+        "@aws-cdk/aws-kms": "1.154.0",
+        "@aws-cdk/cloud-assembly-schema": "1.154.0",
+        "@aws-cdk/core": "1.154.0",
+        "constructs": "^3.3.69"
+      },
+      "dependencies": {
+        "constructs": {
+          "version": "3.3.283",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.283.tgz",
+          "integrity": "sha512-0LbWDLDPE6sa19F87kTg/a+7ZhO6YXaGs3JYPYcYcd1vzastOUbJQ+GY9O7BweDMLj0Hcw4WP33qV0SFmGnipQ=="
+        }
+      }
+    },
+    "@aws-cdk/aws-stepfunctions": {
+      "version": "1.154.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-stepfunctions/-/aws-stepfunctions-1.154.0.tgz",
+      "integrity": "sha512-v03WnIjGCGQtiUSXvyc+mvMZtVbVKgXHjZMy+Kcf99fOgo5AMJNM3ZH+vAXJMl7L6yHav7BCgqe2JfbhoDaphg==",
+      "requires": {
+        "@aws-cdk/aws-cloudwatch": "1.154.0",
+        "@aws-cdk/aws-events": "1.154.0",
+        "@aws-cdk/aws-iam": "1.154.0",
+        "@aws-cdk/aws-logs": "1.154.0",
+        "@aws-cdk/aws-s3": "1.154.0",
+        "@aws-cdk/core": "1.154.0",
+        "constructs": "^3.3.69"
+      },
+      "dependencies": {
+        "constructs": {
+          "version": "3.3.283",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.283.tgz",
+          "integrity": "sha512-0LbWDLDPE6sa19F87kTg/a+7ZhO6YXaGs3JYPYcYcd1vzastOUbJQ+GY9O7BweDMLj0Hcw4WP33qV0SFmGnipQ=="
+        }
+      }
+    },
+    "@aws-cdk/cloud-assembly-schema": {
+      "version": "1.154.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.154.0.tgz",
+      "integrity": "sha512-ujMVD0P/V3qwAjANiwm6zVeDRCihuAq1D4ch2HUyusyHiG1r3/fxT/7as6F6y4fbxElhtUxNdskbPBEZiGyxTA==",
+      "requires": {
+        "jsonschema": "^1.4.0",
+        "semver": "^7.3.6"
+      },
+      "dependencies": {
+        "jsonschema": {
+          "version": "1.4.0",
+          "bundled": true
+        },
+        "lru-cache": {
+          "version": "7.8.0",
+          "bundled": true
+        },
+        "semver": {
+          "version": "7.3.6",
+          "bundled": true,
+          "requires": {
+            "lru-cache": "^7.4.0"
+          }
+        }
+      }
+    },
+    "@aws-cdk/core": {
+      "version": "1.154.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/core/-/core-1.154.0.tgz",
+      "integrity": "sha512-ovmWJGBd1PfPzWTnNXZK23bfrByQgI5hnKe28k7b53NnN7htwceCdJV2p0CmXCQkkkG5jg+JP2PmeJnDsHLUOw==",
+      "requires": {
+        "@aws-cdk/cloud-assembly-schema": "1.154.0",
+        "@aws-cdk/cx-api": "1.154.0",
+        "@aws-cdk/region-info": "1.154.0",
+        "@balena/dockerignore": "^1.0.2",
+        "constructs": "^3.3.69",
+        "fs-extra": "^9.1.0",
+        "ignore": "^5.2.0",
+        "minimatch": "^3.1.2"
+      },
+      "dependencies": {
+        "@balena/dockerignore": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "at-least-node": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "balanced-match": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "constructs": {
+          "version": "3.3.283",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.283.tgz",
+          "integrity": "sha512-0LbWDLDPE6sa19F87kTg/a+7ZhO6YXaGs3JYPYcYcd1vzastOUbJQ+GY9O7BweDMLj0Hcw4WP33qV0SFmGnipQ=="
+        },
+        "fs-extra": {
+          "version": "9.1.0",
+          "bundled": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.2.10",
+          "bundled": true
+        },
+        "ignore": {
+          "version": "5.2.0",
+          "bundled": true
+        },
+        "jsonfile": {
+          "version": "6.1.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^2.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.1.2",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "universalify": {
+          "version": "2.0.0",
+          "bundled": true
+        }
+      }
+    },
+    "@aws-cdk/custom-resources": {
+      "version": "1.154.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/custom-resources/-/custom-resources-1.154.0.tgz",
+      "integrity": "sha512-emf6gLH9qU3Phe4+W9hFXRn16c+U8Z9Ks6sJQWMEPnunLvnFWrQXAxYOAqDjkEUgPLfILCC8qIsamEpXJXdJXg==",
+      "requires": {
+        "@aws-cdk/aws-cloudformation": "1.154.0",
+        "@aws-cdk/aws-ec2": "1.154.0",
+        "@aws-cdk/aws-iam": "1.154.0",
+        "@aws-cdk/aws-lambda": "1.154.0",
+        "@aws-cdk/aws-logs": "1.154.0",
+        "@aws-cdk/aws-sns": "1.154.0",
+        "@aws-cdk/core": "1.154.0",
+        "constructs": "^3.3.69"
+      },
+      "dependencies": {
+        "constructs": {
+          "version": "3.3.283",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.283.tgz",
+          "integrity": "sha512-0LbWDLDPE6sa19F87kTg/a+7ZhO6YXaGs3JYPYcYcd1vzastOUbJQ+GY9O7BweDMLj0Hcw4WP33qV0SFmGnipQ=="
+        }
+      }
+    },
+    "@aws-cdk/cx-api": {
+      "version": "1.154.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cx-api/-/cx-api-1.154.0.tgz",
+      "integrity": "sha512-BOA2sG/kv3DPAsKGPKC2utBRNBj6yVsYHZAwEBCDQSQ20RuuKHdB9xdrtEpc4eOGceLtQDJGHvQhm9dHv4z0pA==",
+      "requires": {
+        "@aws-cdk/cloud-assembly-schema": "1.154.0",
+        "semver": "^7.3.6"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "7.8.0",
+          "bundled": true
+        },
+        "semver": {
+          "version": "7.3.6",
+          "bundled": true,
+          "requires": {
+            "lru-cache": "^7.4.0"
+          }
+        }
+      }
+    },
+    "@aws-cdk/region-info": {
+      "version": "1.154.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/region-info/-/region-info-1.154.0.tgz",
+      "integrity": "sha512-w940Oc2d74oRpoE0o+DyhjWylbDWbQznDvfORD3SSEPhG32eVMUs7HL64j5Ow0EYRA2HACNvWkqMwcsyysIDmg=="
+    },
+    "@types/node": {
+      "version": "17.0.31",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.31.tgz",
+      "integrity": "sha512-AR0x5HbXGqkEx9CadRH3EBYx/VkiUgZIhP4wvPn/+5KIsgpNoyFaRlVe0Zlx9gRtg8fA06a9tskE2MSN7TcG4Q==",
+      "dev": true
+    },
+    "aws-cdk": {
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.22.0.tgz",
+      "integrity": "sha512-oF3VCv/rtuLk8eLb6CBEWvEobabG8q05ersawGEy9CBhKbKNjfY1FDz6gc3ssksTwfcJqyJms2l/BQlLMBjugw==",
+      "requires": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "aws-cdk-lib": {
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.22.0.tgz",
+      "integrity": "sha512-Orz+c746XGm1QBJKb3Wh6qH2rpmHdYMS5A4Wk91niYzrY4Q2kck/XLeQtEwOzscbW2Hqwc6vXTEpkldAI2pzGw==",
+      "requires": {
+        "@balena/dockerignore": "^1.0.2",
+        "case": "1.6.3",
+        "fs-extra": "^9.1.0",
+        "ignore": "^5.2.0",
+        "jsonschema": "^1.4.0",
+        "minimatch": "^3.1.2",
+        "punycode": "^2.1.1",
+        "semver": "^7.3.6",
+        "yaml": "1.10.2"
+      },
+      "dependencies": {
+        "@balena/dockerignore": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "at-least-node": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "balanced-match": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "case": {
+          "version": "1.6.3",
+          "bundled": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "fs-extra": {
+          "version": "9.1.0",
+          "bundled": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.2.10",
+          "bundled": true
+        },
+        "ignore": {
+          "version": "5.2.0",
+          "bundled": true
+        },
+        "jsonfile": {
+          "version": "6.1.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^2.0.0"
+          }
+        },
+        "jsonschema": {
+          "version": "1.4.0",
+          "bundled": true
+        },
+        "lru-cache": {
+          "version": "7.8.0",
+          "bundled": true
+        },
+        "minimatch": {
+          "version": "3.1.2",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "punycode": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "semver": {
+          "version": "7.3.6",
+          "bundled": true,
+          "requires": {
+            "lru-cache": "^7.4.0"
+          }
+        },
+        "universalify": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "yaml": {
+          "version": "1.10.2",
+          "bundled": true
+        }
+      }
+    },
+    "constructs": {
+      "version": "10.0.130",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.0.130.tgz",
+      "integrity": "sha512-9LYBePJHHnuXCr42eN0T4+O8xXHRxxak6G/UX+avt8ZZ/SNE9HFbFD8a+FKP8ixSNzzaEamDMswrMwPPTtU8cA=="
+    },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "optional": true
+    },
+    "prettier": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
+      "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew=="
+    },
+    "typescript": {
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg=="
+    }
+  }
+}

--- a/src/monitoring_resources/cli_binary_integrity/package.json
+++ b/src/monitoring_resources/cli_binary_integrity/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@aws-amplify/monitoring-cli",
+  "version": "1.0.0",
+  "description": "Infrastructure for monitoring cli releases",
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w",
+    "test": "jest",
+    "cdk": "cdk"
+  },
+  "bin": {
+    "monitoring-cli": "bin/monitoring-cli.js"
+  },
+  "dependencies": {
+    "@aws-cdk/aws-lambda": "^1.154.0",
+    "@aws-cdk/aws-lambda-event-sources": "^1.154.0",
+    "@aws-cdk/aws-s3": "^1.154.0",
+    "@aws-cdk/core": "^1.154.0",
+    "aws-cdk": "^2.22.0",
+    "aws-cdk-lib": "^2.22.0",
+    "constructs": "^10.0.130",
+    "prettier": "^2.6.2",
+    "typescript": "^4.6.4"
+  },
+  "devDependencies": {
+    "@types/node": "^17.0.31"
+  }
+}

--- a/src/monitoring_resources/cli_binary_integrity/src/index.ts
+++ b/src/monitoring_resources/cli_binary_integrity/src/index.ts
@@ -1,0 +1,70 @@
+const crypto = require('crypto');
+const fs = require('fs');
+const stream = require('stream');
+const util = require('util');
+const { createGunzip } = require('zlib');
+const tar = require('tar-stream');
+const { KMSClient, MessageType, SigningAlgorithmSpec, VerifyCommand } = require("@aws-sdk/client-kms");
+const AWS = require('aws-sdk');
+const { Readable } = require('stream');
+
+const s3 = new AWS.S3();
+const kms = new KMSClient({ region: "us-east-1" });
+const pipeline = util.promisify(stream.pipeline);
+
+exports.handler = async function (event: any) {
+  const verifyBinary = async (binaryBuffer: Buffer, signatureDigestBuffer: Buffer): Promise<void> => {
+    const hashSum = crypto.createHash('sha512');
+    hashSum.update(binaryBuffer);
+    const message = hashSum.digest();
+
+    const command = new VerifyCommand({
+      KeyId: 'alias/s3-sign-verify',
+      Message: new Uint8Array(message),
+      MessageType: MessageType.DIGEST,
+      Signature: new Uint8Array(signatureDigestBuffer),
+      SigningAlgorithm: SigningAlgorithmSpec.RSASSA_PSS_SHA_512,
+    });
+    const data = await kms.send(command);
+    if (!data?.SignatureValid) {
+      throw new Error(`Unable to verify integrity of ${this.binaryPath}`);
+    }
+  }
+  const extract = () => {
+    const extract = tar.extract();
+    const chunks: Uint8Array[] = [];
+    const signatureChunks: Uint8Array[] = [];
+    extract.on('entry', (header: any, extractStream: any, next: any) => {
+      if (header.type === 'file') {
+        extractStream.on('data', (chunk: any) => {
+          if (header.name === this.signatureDigestFilename) {
+            signatureChunks.push(chunk);
+          } else {
+            chunks.push(chunk);
+          }
+        });
+      }
+      extractStream.on('end', () => {
+        next();
+      });
+
+      extractStream.resume();
+    });
+    extract.on('finish', async () => {
+      await verifyBinary(Buffer.concat(chunks), Buffer.concat(signatureChunks));
+    });
+    return extract;
+  }
+  const promises = event.Records.map(async (record: any) => {
+      const object = await s3.getObject({
+          Bucket: record.s3.bucket.name,
+          Key: record.s3.object.key,
+      }).createReadStream();
+      await pipeline(
+        object,
+        createGunzip(),
+        extract(),
+      );
+  });
+  await Promise.all(promises);
+};

--- a/src/monitoring_resources/cli_binary_integrity/src/package-lock.json
+++ b/src/monitoring_resources/cli_binary_integrity/src/package-lock.json
@@ -1,0 +1,1004 @@
+{
+  "name": "src",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@aws-crypto/ie11-detection": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.0.tgz",
+      "integrity": "sha512-pkVXf/dq6PITJ0jzYZ69VhL8VFOFoPZLZqtU/12SGnzYuJOOGNfF41q9GxdI1yqC8R13Rq3jOLKDFpUJFT5eTA==",
+      "requires": {
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/sha256-browser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
+      "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+      "requires": {
+        "@aws-crypto/ie11-detection": "^2.0.0",
+        "@aws-crypto/sha256-js": "^2.0.0",
+        "@aws-crypto/supports-web-crypto": "^2.0.0",
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/sha256-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
+      "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+      "requires": {
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/supports-web-crypto": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.0.tgz",
+      "integrity": "sha512-Ge7WQ3E0OC7FHYprsZV3h0QIcpdyJLvIeg+uTuHqRYm8D6qCFJoiC+edSzSyFiHtZf+NOQDJ1q46qxjtzIY2nA==",
+      "requires": {
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/util": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.1.tgz",
+      "integrity": "sha512-JJmFFwvbm08lULw4Nm5QOLg8+lAQeC8aCXK5xrtxntYzYXCGfHwUJ4Is3770Q7HmICsXthGQ+ZsDL7C2uH3yBQ==",
+      "requires": {
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/abort-controller": {
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.78.0.tgz",
+      "integrity": "sha512-iz1YLwM2feJUj/y97yO4XmDeTxs+yZ1XJwQgoawKuc8IDBKUutnJNCHL5jL04WUKU7Nrlq+Hr2fCTScFh2z9zg==",
+      "requires": {
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/client-kms": {
+      "version": "3.82.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kms/-/client-kms-3.82.0.tgz",
+      "integrity": "sha512-bXcB6qdT/Vryyen0Yccxrf55B3ZVrRcHqeYNU+3D8LM3mWH+Cy4a1T5RPrc90WKJjofHDBJrURR+MmK/ny58Iw==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/client-sts": "3.82.0",
+        "@aws-sdk/config-resolver": "3.80.0",
+        "@aws-sdk/credential-provider-node": "3.82.0",
+        "@aws-sdk/fetch-http-handler": "3.78.0",
+        "@aws-sdk/hash-node": "3.78.0",
+        "@aws-sdk/invalid-dependency": "3.78.0",
+        "@aws-sdk/middleware-content-length": "3.78.0",
+        "@aws-sdk/middleware-host-header": "3.78.0",
+        "@aws-sdk/middleware-logger": "3.78.0",
+        "@aws-sdk/middleware-retry": "3.80.0",
+        "@aws-sdk/middleware-serde": "3.78.0",
+        "@aws-sdk/middleware-signing": "3.78.0",
+        "@aws-sdk/middleware-stack": "3.78.0",
+        "@aws-sdk/middleware-user-agent": "3.78.0",
+        "@aws-sdk/node-config-provider": "3.80.0",
+        "@aws-sdk/node-http-handler": "3.82.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/smithy-client": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/url-parser": "3.78.0",
+        "@aws-sdk/util-base64-browser": "3.58.0",
+        "@aws-sdk/util-base64-node": "3.55.0",
+        "@aws-sdk/util-body-length-browser": "3.55.0",
+        "@aws-sdk/util-body-length-node": "3.55.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.78.0",
+        "@aws-sdk/util-defaults-mode-node": "3.81.0",
+        "@aws-sdk/util-user-agent-browser": "3.78.0",
+        "@aws-sdk/util-user-agent-node": "3.80.0",
+        "@aws-sdk/util-utf8-browser": "3.55.0",
+        "@aws-sdk/util-utf8-node": "3.55.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/client-sso": {
+      "version": "3.82.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.82.0.tgz",
+      "integrity": "sha512-zfscjrufPLh1RwdVMDx+5xxZbrY64UD4aSHlmWcPxE8ySj2MVfoE18EBQcCgY82U5QgssT7yxtUirxyI2b92tw==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.80.0",
+        "@aws-sdk/fetch-http-handler": "3.78.0",
+        "@aws-sdk/hash-node": "3.78.0",
+        "@aws-sdk/invalid-dependency": "3.78.0",
+        "@aws-sdk/middleware-content-length": "3.78.0",
+        "@aws-sdk/middleware-host-header": "3.78.0",
+        "@aws-sdk/middleware-logger": "3.78.0",
+        "@aws-sdk/middleware-retry": "3.80.0",
+        "@aws-sdk/middleware-serde": "3.78.0",
+        "@aws-sdk/middleware-stack": "3.78.0",
+        "@aws-sdk/middleware-user-agent": "3.78.0",
+        "@aws-sdk/node-config-provider": "3.80.0",
+        "@aws-sdk/node-http-handler": "3.82.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/smithy-client": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/url-parser": "3.78.0",
+        "@aws-sdk/util-base64-browser": "3.58.0",
+        "@aws-sdk/util-base64-node": "3.55.0",
+        "@aws-sdk/util-body-length-browser": "3.55.0",
+        "@aws-sdk/util-body-length-node": "3.55.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.78.0",
+        "@aws-sdk/util-defaults-mode-node": "3.81.0",
+        "@aws-sdk/util-user-agent-browser": "3.78.0",
+        "@aws-sdk/util-user-agent-node": "3.80.0",
+        "@aws-sdk/util-utf8-browser": "3.55.0",
+        "@aws-sdk/util-utf8-node": "3.55.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/client-sts": {
+      "version": "3.82.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.82.0.tgz",
+      "integrity": "sha512-gR1dz/a6lMD2U+AUpLUocXDruDDQFCUoknrpzMZPCAVsamrF17dwKKCgKVlz6zseHP6uPMPluuppvYQ16wsYyQ==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.80.0",
+        "@aws-sdk/credential-provider-node": "3.82.0",
+        "@aws-sdk/fetch-http-handler": "3.78.0",
+        "@aws-sdk/hash-node": "3.78.0",
+        "@aws-sdk/invalid-dependency": "3.78.0",
+        "@aws-sdk/middleware-content-length": "3.78.0",
+        "@aws-sdk/middleware-host-header": "3.78.0",
+        "@aws-sdk/middleware-logger": "3.78.0",
+        "@aws-sdk/middleware-retry": "3.80.0",
+        "@aws-sdk/middleware-sdk-sts": "3.78.0",
+        "@aws-sdk/middleware-serde": "3.78.0",
+        "@aws-sdk/middleware-signing": "3.78.0",
+        "@aws-sdk/middleware-stack": "3.78.0",
+        "@aws-sdk/middleware-user-agent": "3.78.0",
+        "@aws-sdk/node-config-provider": "3.80.0",
+        "@aws-sdk/node-http-handler": "3.82.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/smithy-client": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/url-parser": "3.78.0",
+        "@aws-sdk/util-base64-browser": "3.58.0",
+        "@aws-sdk/util-base64-node": "3.55.0",
+        "@aws-sdk/util-body-length-browser": "3.55.0",
+        "@aws-sdk/util-body-length-node": "3.55.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.78.0",
+        "@aws-sdk/util-defaults-mode-node": "3.81.0",
+        "@aws-sdk/util-user-agent-browser": "3.78.0",
+        "@aws-sdk/util-user-agent-node": "3.80.0",
+        "@aws-sdk/util-utf8-browser": "3.55.0",
+        "@aws-sdk/util-utf8-node": "3.55.0",
+        "entities": "2.2.0",
+        "fast-xml-parser": "3.19.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/config-resolver": {
+      "version": "3.80.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.80.0.tgz",
+      "integrity": "sha512-vFruNKlmhsaC8yjnHmasi1WW/7EELlEuFTj4mqcqNqR4dfraf0maVvpqF1VSR8EstpFMsGYI5dmoWAnnG4PcLQ==",
+      "requires": {
+        "@aws-sdk/signature-v4": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-config-provider": "3.55.0",
+        "@aws-sdk/util-middleware": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-env": {
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.78.0.tgz",
+      "integrity": "sha512-K41VTIzVHm2RyIwtBER8Hte3huUBXdV1WKO+i7olYVgLFmaqcZUNrlyoGDRqZcQ/u4AbxTzBU9jeMIbIfzMOWg==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-imds": {
+      "version": "3.81.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.81.0.tgz",
+      "integrity": "sha512-BHopP+gaovTYj+4tSrwCk8NNCR48gE9CWmpIOLkP9ell0gOL81Qh7aCEiIK0BZBZkccv1s16cYq1MSZZGS7PEQ==",
+      "requires": {
+        "@aws-sdk/node-config-provider": "3.80.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/url-parser": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-ini": {
+      "version": "3.82.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.82.0.tgz",
+      "integrity": "sha512-2HrH5Ok/ZpN/81JbIY+HiKjNtGoXP50jyX8a5Dpez41hLuXek7j2ENWRcNOMkPtot+Ri088h661Y7sdzOv1etg==",
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.78.0",
+        "@aws-sdk/credential-provider-imds": "3.81.0",
+        "@aws-sdk/credential-provider-sso": "3.82.0",
+        "@aws-sdk/credential-provider-web-identity": "3.78.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/shared-ini-file-loader": "3.80.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-node": {
+      "version": "3.82.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.82.0.tgz",
+      "integrity": "sha512-jjZj5h+tKaFBl/RnZ4Atpdtot6ZK4F2EBC8t+sNnFhPqcnhO42+7tLZ/aXhdY1oCvD54RG3exHFRsY6qDe8MhQ==",
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.78.0",
+        "@aws-sdk/credential-provider-imds": "3.81.0",
+        "@aws-sdk/credential-provider-ini": "3.82.0",
+        "@aws-sdk/credential-provider-process": "3.80.0",
+        "@aws-sdk/credential-provider-sso": "3.82.0",
+        "@aws-sdk/credential-provider-web-identity": "3.78.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/shared-ini-file-loader": "3.80.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-process": {
+      "version": "3.80.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.80.0.tgz",
+      "integrity": "sha512-3Ro+kMMyLUJHefOhGc5pOO/ibGcJi8bkj0z/Jtqd5I2Sm1qi7avoztST67/k48KMW1OqPnD/FUqxz5T8B2d+FQ==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/shared-ini-file-loader": "3.80.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-sso": {
+      "version": "3.82.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.82.0.tgz",
+      "integrity": "sha512-cOIFD6dohrp/cz3bkT0rxbfHgNA4wXRtOciitbBpNnfxOdu51M9bp+XZFb3tdTfhE9fIr4Y+BGqF6AXWZkikLg==",
+      "requires": {
+        "@aws-sdk/client-sso": "3.82.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/shared-ini-file-loader": "3.80.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-web-identity": {
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.78.0.tgz",
+      "integrity": "sha512-9/IvqHdJaVqMEABA8xZE3t5YF1S2PepfckVu0Ws9YUglj6oO+2QyVX6aRgMF1xph6781+Yc31TDh8/3eaDja7w==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/fetch-http-handler": {
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.78.0.tgz",
+      "integrity": "sha512-cR6r2h2kJ1DNEZSXC6GknQB7OKmy+s9ZNV+g3AsNqkrUmNNOaHpFoSn+m6SC3qaclcGd0eQBpqzSu/TDn23Ihw==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/querystring-builder": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-base64-browser": "3.58.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/hash-node": {
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.78.0.tgz",
+      "integrity": "sha512-ev48yXaqZVtMeuKy52LUZPHCyKvkKQ9uiUebqkA+zFxIk+eN8SMPFHmsififIHWuS6ZkXBUSctjH9wmLebH60A==",
+      "requires": {
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-buffer-from": "3.55.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/invalid-dependency": {
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.78.0.tgz",
+      "integrity": "sha512-zUo+PbeRMN/Mzj6y+6p9qqk/znuFetT1gmpOcZGL9Rp2T+b9WJWd+daq5ktsL10sVCzIt2UvneJRz6b+aU+bfw==",
+      "requires": {
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/is-array-buffer": {
+      "version": "3.55.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.55.0.tgz",
+      "integrity": "sha512-NbiPHVYuPxdqdFd6FxzzN3H1BQn/iWA3ri3Ry7AyLeP/tGs1yzEWMwf8BN8TSMALI0GXT6Sh0GDWy3Ok5xB6DA==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-content-length": {
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.78.0.tgz",
+      "integrity": "sha512-5MpKt6lB9TdFy25/AGrpOjPY0iDHZAKpEHc+jSOJBXLl6xunXA7qHdiYaVqkWodLxy70nIckGNHqQ3drabidkA==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-host-header": {
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.78.0.tgz",
+      "integrity": "sha512-1zL8uaDWGmH50c8B8jjz75e0ePj6/3QeZEhjJgTgL6DTdiqvRt32p3t+XWHW+yDI14fZZUYeTklAaLVxqFrHqQ==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-logger": {
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.78.0.tgz",
+      "integrity": "sha512-GBhwxNjhCJUIeQQDaGasX/C23Jay77al2vRyGwmxf8no0DdFsa4J1Ik6/2hhIqkqko+WM4SpCnpZrY4MtnxNvA==",
+      "requires": {
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-retry": {
+      "version": "3.80.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.80.0.tgz",
+      "integrity": "sha512-CTk+tA4+WMUNOcUfR6UQrkhwvPYFpnMsQ1vuHlpLFOGG3nCqywA2hueLMRQmVcDXzP0sGeygce6dzRI9dJB/GA==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/service-error-classification": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-middleware": "3.78.0",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      }
+    },
+    "@aws-sdk/middleware-sdk-sts": {
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.78.0.tgz",
+      "integrity": "sha512-Lu/kN0J0/Kt0ON1hvwNel+y8yvf35licfIgtedHbBCa/ju8qQ9j+uL9Lla6Y5Tqu29yVaye1JxhiIDhscSwrLA==",
+      "requires": {
+        "@aws-sdk/middleware-signing": "3.78.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/signature-v4": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-serde": {
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.78.0.tgz",
+      "integrity": "sha512-4DPsNOxsl1bxRzfo1WXEZjmD7OEi7qGNpxrDWucVe96Fqj2dH08jR8wxvBIVV1e6bAad07IwdPuCGmivNvwRuQ==",
+      "requires": {
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-signing": {
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.78.0.tgz",
+      "integrity": "sha512-OEjJJCNhHHSOprLZ9CzjHIXEKFtPHWP/bG9pMhkV3/6Bmscsgcf8gWHcOnmIrjqX+hT1VALDNpl/RIh0J6/eQw==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/signature-v4": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-stack": {
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.78.0.tgz",
+      "integrity": "sha512-UoNfRh6eAJN3BJHlG1eb+KeuSe+zARTC2cglroJRyHc2j7GxH2i9FD3IJbj5wvzopJEnQzuY/VCs6STFkqWL1g==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-user-agent": {
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.78.0.tgz",
+      "integrity": "sha512-wdN5uoq8RxxhLhj0EPeuDSRFuXfUwKeEqRzCKMsYAOC0cAm+PryaP2leo0oTGJ9LUK8REK7zyfFcmtC4oOzlkA==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/node-config-provider": {
+      "version": "3.80.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.80.0.tgz",
+      "integrity": "sha512-vyTOMK04huB7n10ZUv0thd2TE6KlY8livOuLqFTMtj99AJ6vyeB5XBNwKnQtJIt/P7CijYgp8KcFvI9fndOmKg==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/shared-ini-file-loader": "3.80.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/node-http-handler": {
+      "version": "3.82.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.82.0.tgz",
+      "integrity": "sha512-yyq/DA/IMzL4fLJhV7zVfP7aUQWPHfOKTCJjWB3KeV5YPiviJtSKb/KyzNi+gQyO7SmsL/8vQbQrf3/s7N/2OA==",
+      "requires": {
+        "@aws-sdk/abort-controller": "3.78.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/querystring-builder": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/property-provider": {
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.78.0.tgz",
+      "integrity": "sha512-PZpLvV0hF6lqg3CSN9YmphrB/t5LVJVWGJLB9d9qm7sJs5ksjTYBb5bY91OQ3zit0F4cqBMU8xt2GQ9J6d4DvQ==",
+      "requires": {
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/protocol-http": {
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.78.0.tgz",
+      "integrity": "sha512-SQB26MhEK96yDxyXd3UAaxLz1Y/ZvgE4pzv7V3wZiokdEedM0kawHKEn1UQJlqJLEZcQI9QYyysh3rTvHZ3fyg==",
+      "requires": {
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/querystring-builder": {
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.78.0.tgz",
+      "integrity": "sha512-aib6RW1WAaTQDqVgRU1Ku9idkhm90gJKbCxVaGId+as6QHNUqMChEfK2v+0afuKiPNOs5uWmqvOXI9+Gt+UGDg==",
+      "requires": {
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-uri-escape": "3.55.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/querystring-parser": {
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.78.0.tgz",
+      "integrity": "sha512-csaH8YTyN+KMNczeK6fBS8l7iJaqcQcKOIbpQFg5upX4Ly5A56HJn4sVQhY1LSgfSk4xRsNfMy5mu6BlsIiaXA==",
+      "requires": {
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/service-error-classification": {
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.78.0.tgz",
+      "integrity": "sha512-x7Lx8KWctJa01q4Q72Zb4ol9L/era3vy2daASu8l2paHHxsAPBE0PThkvLdUSLZSzlHSVdh3YHESIsT++VsK4w=="
+    },
+    "@aws-sdk/shared-ini-file-loader": {
+      "version": "3.80.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.80.0.tgz",
+      "integrity": "sha512-3d5EBJjnWWkjLK9skqLLHYbagtFaZZy+3jUTlbTuOKhlOwe8jF7CUM3j6I4JA6yXNcB3w0exDKKHa8w+l+05aA==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/signature-v4": {
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.78.0.tgz",
+      "integrity": "sha512-eePjRYuzKoi3VMr/lgrUEF1ytLeH4fA/NMCykr/uR6NMo4bSJA59KrFLYSM7SlWLRIyB0UvJqygVEvSxFluyDw==",
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.55.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-hex-encoding": "3.58.0",
+        "@aws-sdk/util-middleware": "3.78.0",
+        "@aws-sdk/util-uri-escape": "3.55.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/smithy-client": {
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.78.0.tgz",
+      "integrity": "sha512-qweaupZtFPm9rFiEgErnVNgB6co/DylJfhC6/UImHBKa7mGzxv6t2JDm6+d8fs8cNnGNXozN+jJG8Lz6C8Roxw==",
+      "requires": {
+        "@aws-sdk/middleware-stack": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/types": {
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.78.0.tgz",
+      "integrity": "sha512-I9PTlVNSbwhIgMfmDM5as1tqRIkVZunjVmfogb2WVVPp4CaX0Ll01S0FSMSLL9k6tcQLXqh45pFRjrxCl9WKdQ=="
+    },
+    "@aws-sdk/url-parser": {
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.78.0.tgz",
+      "integrity": "sha512-iQn2AjECUoJE0Ae9XtgHtGGKvUkvE8hhbktGopdj+zsPBe4WrBN2DgVxlKPPrBonG/YlcL1D7a5EXaujWSlUUw==",
+      "requires": {
+        "@aws-sdk/querystring-parser": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-base64-browser": {
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.58.0.tgz",
+      "integrity": "sha512-0ebsXIZNpu/fup9OgsFPnRKfCFbuuI9PPRzvP6twzLxUB0c/aix6Co7LGHFKcRKHZdaykoJMXArf8eHj2Nzv1Q==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-base64-node": {
+      "version": "3.55.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.55.0.tgz",
+      "integrity": "sha512-UQ/ZuNoAc8CFMpSiRYmevaTsuRKzLwulZTnM8LNlIt9Wx1tpNvqp80cfvVj7yySKROtEi20wq29h31dZf1eYNQ==",
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.55.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-body-length-browser": {
+      "version": "3.55.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.55.0.tgz",
+      "integrity": "sha512-Ei2OCzXQw5N6ZkTMZbamUzc1z+z1R1Ja5tMEagz5BxuX4vWdBObT+uGlSzL8yvTbjoPjnxWA2aXyEqaUP3JS8Q==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-body-length-node": {
+      "version": "3.55.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.55.0.tgz",
+      "integrity": "sha512-lU1d4I+9wJwydduXs0SxSfd+mHKjxeyd39VwOv6i2KSwWkPbji9UQqpflKLKw+r45jL7+xU/zfeTUg5Tt/3Gew==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-buffer-from": {
+      "version": "3.55.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.55.0.tgz",
+      "integrity": "sha512-uVzKG1UgvnV7XX2FPTylBujYMKBPBaq/qFBxfl0LVNfrty7YjpfieQxAe6yRLD+T0Kir/WDQwGvYC+tOYG3IGA==",
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.55.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-config-provider": {
+      "version": "3.55.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.55.0.tgz",
+      "integrity": "sha512-30dzofQQfx6tp1jVZkZ0DGRsT0wwC15nEysKRiAcjncM64A0Cm6sra77d0os3vbKiKoPCI/lMsFr4o3533+qvQ==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.78.0.tgz",
+      "integrity": "sha512-fsKEqlRbrztjpdTsMbZTlWxFpo3Av9QeYYpJuFaZbwfE0ElzinUU54kKwUrKbi60HRroQV+itoUNj3JogQDeHw==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-defaults-mode-node": {
+      "version": "3.81.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.81.0.tgz",
+      "integrity": "sha512-+7YOtl+TxF08oXt2h/ONP5qk6ZZg6GaO1YSAdpjIfco4odhpy7N2AlEGSX0jZyP6Zbfi+8N7yihBa4sOuOf+Cw==",
+      "requires": {
+        "@aws-sdk/config-resolver": "3.80.0",
+        "@aws-sdk/credential-provider-imds": "3.81.0",
+        "@aws-sdk/node-config-provider": "3.80.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-hex-encoding": {
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.58.0.tgz",
+      "integrity": "sha512-Rl+jXUzk/FJkOLYfUVYPhKa2aUmTpeobRP31l8IatQltSzDgLyRHO35f6UEs7Ztn5s1jbu/POatLAZ2WjbgVyg==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-locate-window": {
+      "version": "3.55.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.55.0.tgz",
+      "integrity": "sha512-0sPmK2JaJE2BbTcnvybzob/VrFKCXKfN4CUKcvn0yGg/me7Bz+vtzQRB3Xp+YSx+7OtWxzv63wsvHoAnXvgxgg==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-middleware": {
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.78.0.tgz",
+      "integrity": "sha512-Hi3wv2b0VogO4mzyeEaeU5KgIt4qeo0LXU5gS6oRrG0T7s2FyKbMBkJW3YDh/Y8fNwqArZ+/QQFujpP0PIKwkA==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-uri-escape": {
+      "version": "3.55.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.55.0.tgz",
+      "integrity": "sha512-mmdDLUpFCN2nkfwlLdOM54lTD528GiGSPN1qb8XtGLgZsJUmg3uJSFIN2lPeSbEwJB3NFjVas/rnQC48i7mV8w==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-user-agent-browser": {
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.78.0.tgz",
+      "integrity": "sha512-diGO/Bf4ggBOEnfD7lrrXaaXOwOXGz0bAJ0HhpizwEMlBld5zfDlWXjNpslh+8+u3EHRjPJQ16KGT6mp/Dm+aw==",
+      "requires": {
+        "@aws-sdk/types": "3.78.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-user-agent-node": {
+      "version": "3.80.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.80.0.tgz",
+      "integrity": "sha512-QV26qIXws1m6sZXg65NS+XrQ5NhAzbDVQLtEVE4nC39UN8fuieP6Uet/gZm9mlLI9hllwvcV7EfgBM3GSC7pZg==",
+      "requires": {
+        "@aws-sdk/node-config-provider": "3.80.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-utf8-browser": {
+      "version": "3.55.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.55.0.tgz",
+      "integrity": "sha512-ljzqJcyjfJpEVSIAxwtIS8xMRUly84BdjlBXyp6cu4G8TUufgjNS31LWdhyGhgmW5vYBNr+LTz0Kwf6J+ou7Ug==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-utf8-node": {
+      "version": "3.55.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.55.0.tgz",
+      "integrity": "sha512-FsFm7GFaC7j0tlPEm/ri8bU2QCwFW5WKjxUg8lm1oWaxplCpKGUsmcfPJ4sw58GIoyoGu4QXBK60oCWosZYYdQ==",
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.55.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "aws-sdk": {
+      "version": "2.1127.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1127.0.tgz",
+      "integrity": "sha512-jtP0CV89m2XNfgi1SnomrK798QqLmR+340w4KOMF0vBkY9kvGzPLV9GBNcg3JPj45tML1H4hSIonYkUUFSLkYw==",
+      "requires": {
+        "buffer": "4.9.2",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.16.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "4.9.2",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+          "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4",
+            "isarray": "^1.0.0"
+          }
+        },
+        "ieee754": {
+          "version": "1.1.13",
+          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+          "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+        }
+      }
+    },
+    "axios": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "requires": {
+        "follow-redirects": "^1.14.8"
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
+    "bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "requires": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
+    "entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
+    },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+    },
+    "fast-xml-parser": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
+      "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg=="
+    },
+    "follow-redirects": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.0.tgz",
+      "integrity": "sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ=="
+    },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "glob": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "jmespath": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw=="
+    },
+    "minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+    },
+    "readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      }
+    },
+    "rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+    },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "requires": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      }
+    },
+    "tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+    },
+    "url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+    }
+  }
+}

--- a/src/monitoring_resources/cli_binary_integrity/src/package.json
+++ b/src/monitoring_resources/cli_binary_integrity/src/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "src",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@aws-sdk/client-kms": "^3.82.0",
+    "aws-sdk": "^2.1127.0",
+    "axios": "^0.26.0",
+    "rimraf": "^3.0.2",
+    "tar-stream": "^2.2.0"
+  }
+}

--- a/src/monitoring_resources/cli_binary_integrity/tsconfig.json
+++ b/src/monitoring_resources/cli_binary_integrity/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2018",
+    "module": "commonjs",
+    "lib": ["es2016", "es2017.object", "es2017.string"],
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": false,
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "experimentalDecorators": true,
+    "strictPropertyInitialization": false
+  }
+}


### PR DESCRIPTION
This PR adds an event handler to our CLI binary s3 bucket that verifies all files uploaded to the s3. Currently, alarms are disabled because our deployment pipeline does not yet include the proper signatures.