### PR TITLE
chore: update timeout to 30 sec, add error to slack msgs

### DIFF
--- a/src/credentials_rotators/npm-token-rotation/src/lambda/step-01-publish-token/index.ts
+++ b/src/credentials_rotators/npm-token-rotation/src/lambda/step-01-publish-token/index.ts
@@ -104,7 +104,7 @@ export const handler = async (event: TokenRotationStepFnEvent) => {
       if (webhookUrl) {
         await utils.sendSlackMessage(
           webhookUrl,
-          "NPM Access token has been rotation failed"
+          `NPM Access token has been rotation failed: ${e}`,
         );
       }
       throw e;

--- a/src/credentials_rotators/npm-token-rotation/src/lambda/step-01-publish-token/index.ts
+++ b/src/credentials_rotators/npm-token-rotation/src/lambda/step-01-publish-token/index.ts
@@ -104,7 +104,7 @@ export const handler = async (event: TokenRotationStepFnEvent) => {
       if (webhookUrl) {
         await utils.sendSlackMessage(
           webhookUrl,
-          `NPM Access token has been rotation failed: ${e}`,
+          `NPM Access token rotation failed. Runbook: https://tiny.amazon.com/rv8519a6 Error: ${e}`,
         );
       }
       throw e;

--- a/src/credentials_rotators/npm-token-rotation/src/lambda/step-02-delete-old-token/index.ts
+++ b/src/credentials_rotators/npm-token-rotation/src/lambda/step-02-delete-old-token/index.ts
@@ -52,7 +52,7 @@ export const handler = async (event: TokenRotationStepFnEvent) => {
     console.info(`end: handler(${JSON.stringify(event)})`);
   } catch (e) {
     if (webhookUrl) {
-      sendSlackMessage(webhookUrl, "Deleting the old NPM token failed");
+      sendSlackMessage(webhookUrl, `Deleting the old NPM token failed: ${e}`);
     }
     throw e;
   }

--- a/src/credentials_rotators/npm-token-rotation/src/lambda/step-02-delete-old-token/index.ts
+++ b/src/credentials_rotators/npm-token-rotation/src/lambda/step-02-delete-old-token/index.ts
@@ -52,7 +52,7 @@ export const handler = async (event: TokenRotationStepFnEvent) => {
     console.info(`end: handler(${JSON.stringify(event)})`);
   } catch (e) {
     if (webhookUrl) {
-      sendSlackMessage(webhookUrl, `Deleting the old NPM token failed: ${e}`);
+      sendSlackMessage(webhookUrl, `Deleting the old NPM token failed. Runbook: https://tiny.amazon.com/rv8519a6 Error: ${e}`);
     }
     throw e;
   }

--- a/src/credentials_rotators/npm-token-rotation/src/stacks/base-stack.ts
+++ b/src/credentials_rotators/npm-token-rotation/src/stacks/base-stack.ts
@@ -107,6 +107,7 @@ export class BaseStack extends core.Stack {
       threshold: 1,
       evaluationPeriods: 1,
       alarmName: `${name}-alarm`,
+      alarmDescription: 'See https://tiny.amazon.com/rv8519a6',
     });
     alarm.addAlarmAction(new SnsAction(topic));
   };

--- a/src/credentials_rotators/npm-token-rotation/src/stacks/base-stack.ts
+++ b/src/credentials_rotators/npm-token-rotation/src/stacks/base-stack.ts
@@ -107,7 +107,7 @@ export class BaseStack extends core.Stack {
       threshold: 1,
       evaluationPeriods: 1,
       alarmName: `${name}-alarm`,
-      alarmDescription: 'See https://tiny.amazon.com/rv8519a6',
+      alarmDescription: 'Runbook https://tiny.amazon.com/rv8519a6',
     });
     alarm.addAlarmAction(new SnsAction(topic));
   };

--- a/src/credentials_rotators/npm-token-rotation/src/stacks/npm-token-rotation.ts
+++ b/src/credentials_rotators/npm-token-rotation/src/stacks/npm-token-rotation.ts
@@ -62,7 +62,7 @@ export class NpmTokenRotationStack extends BaseStack {
     );
 
     const deleteOldTokenStateMachine = this.buildTokenDeletionStateMachine(
-      core.Duration.minutes(15),
+      core.Duration.minutes(30),
       tokenPublisherFn,
       tokenRemovalFn
     );

--- a/src/credentials_rotators/npm-token-rotation/src/stacks/npm-token-rotation.ts
+++ b/src/credentials_rotators/npm-token-rotation/src/stacks/npm-token-rotation.ts
@@ -24,6 +24,7 @@ export class NpmTokenRotationStack extends BaseStack {
     super(scope, id);
     this.secretConfig = options.config;
     const rotatorFn = new lambdaNodeJs.NodejsFunction(this, "lambda", {
+      timeout: core.Duration.seconds(30),
       entry: path.normalize(
         path.join(__dirname, "..", "lambda", "create-new-token", "index.ts")
       ),
@@ -62,7 +63,7 @@ export class NpmTokenRotationStack extends BaseStack {
     );
 
     const deleteOldTokenStateMachine = this.buildTokenDeletionStateMachine(
-      core.Duration.minutes(30),
+      core.Duration.minutes(15),
       tokenPublisherFn,
       tokenRemovalFn
     );


### PR DESCRIPTION
*Description of changes:*
- update npm-token-rotation timeout to 30 seconds for token creation
- add error to slack messages on failure
- add alarm description

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
