### PR TITLE
fix(npm-token-rotation): fix typo in variables.type equality check

### DIFF
--- a/src/credentials_rotators/npm-token-rotation/src/lambda/utils/circleci-helper.ts
+++ b/src/credentials_rotators/npm-token-rotation/src/lambda/utils/circleci-helper.ts
@@ -38,7 +38,7 @@ export const updateCircleCIEnvironmentVariables = async (
         envName,
         envValue
       );
-    } else if ((variables.type = "Environment")) {
+    } else if (variables.type === "Environment") {
       await updateCircleCIEnvironmentVariable(
         variables.slug,
         variables.projectName,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Fixes typo in https://github.com/aws-amplify/amplify-ci-support/blob/eedce19e9dc650eff285bd2a7483220d58fafb0b/src/credentials_rotators/npm-token-rotation/src/lambda/utils/circleci-helper.ts#L41

`=` should be `===`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
