### PR TITLE
fix: correct CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 *                                                @aws-amplify/amplify-ios
 src/build_infrastructure/android/*               @aws-amplify/amplify-android
-src/credentials_rotators/npm/*                   @aws-amplify/amplify-codegen
+src/credentials_rotators/npm/*                   @aws-amplify/amplify-data
 src/credentials_rotators/npm-token-rotation/*    @aws-amplify/amplify-cli
 src/integ_test_resources/android/*               @aws-amplify/amplify-android
 src/orbs/*                                       @aws-amplify/amplify-devops


### PR DESCRIPTION
The CODEOWNERS file appears to have a parsing bug because the codegen team no longer exists in Github. Replacing with data team which now exists and is appropriate owner.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
