### PR TITLE
fix: don't log credentials (amplify-s3-token-rotation-lambda)

### DIFF
--- a/lambda/index.ts
+++ b/lambda/index.ts
@@ -13,7 +13,6 @@ exports.handler = async function() {
   const promiseFns = config.circleCiConfigs.map(circleCiConfig => {
     return async () => {
       const credentials = await generateTemporaryKey(circleCiConfig.roleName);
-      console.log(credentials);
       await updateCircleCiEnvironmentVariables(
         circleCiConfig as CircleCiConfig,
         credentials,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
`console.log(credentials)` causes credentials to be stored in CloudWatch logs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
