### PR TITLE
chore: Allow an empty Changelog body

### DIFF
--- a/src/fastlane/release_actions/fastlane/AndroidAppsFastfile
+++ b/src/fastlane/release_actions/fastlane/AndroidAppsFastfile
@@ -249,6 +249,8 @@ platform :android do |options|
       }
     )
 
+    changelog = '' if changelog.nil?
+
     # Add links to anything that looks like a GitHub issue/PR number. This will replace e.g. #1234 with a link
     # to the corresponding issue. It links directly to /issues/# but that will redirect to pull/# if the link is for a pull request.
     repo = options[:repo]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
If we try to run our fastlane action for a release that has no customer-impacting changes the script fails because the conventional changelog is `nil`. Replace that with an empty string for the rest of the script's use.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
