### PR TITLE
fix(android): Take the last part of the base branch ref

### DIFF
--- a/src/fastlane/release_actions/fastlane/AndroidAppsFastfile
+++ b/src/fastlane/release_actions/fastlane/AndroidAppsFastfile
@@ -72,7 +72,8 @@ platform :android do |options|
     end
 
     # Default to opening a PR against "main" if not specified
-    base_branch = options.fetch(:base_branch, "main")
+    # If a branch ref is specified (e.g. "refs/heads/main") then just take the last part
+    base_branch = options.fetch(:base_branch, "main").split("/").last
 
     product_name = build_parameters[:product_name]
     repo = build_parameters[:repo]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Only take the last part of the base_branch (e.g. "refs/heads/main" -> "main") when creating a release PR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
