### PR TITLE
Update CODEOWNERS paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
-*                                                @aws-amplify/amplify-ios
-src/build_infrastructure/android/*               @aws-amplify/amplify-android
-src/credentials_rotators/npm/*                   @aws-amplify/amplify-data
-src/credentials_rotators/npm-token-rotation/*    @aws-amplify/amplify-cli
-src/integ_test_resources/android/*               @aws-amplify/amplify-android
-src/orbs/*                                       @aws-amplify/amplify-devops
-src/monitoring_resources/cli_binary_integrity/*  @aws-amplify/amplify-cli
-src/integ_test_resources/flutter/*               @aws-amplify/amplify-flutter
+*                                                 @aws-amplify/amplify-ios
+src/build_infrastructure/android/**               @aws-amplify/amplify-android
+src/credentials_rotators/npm/**                   @aws-amplify/amplify-data
+src/credentials_rotators/npm-token-rotation/**    @aws-amplify/amplify-cli
+src/integ_test_resources/android/**               @aws-amplify/amplify-android
+src/orbs/**                                       @aws-amplify/amplify-devops
+src/monitoring_resources/cli_binary_integrity/**  @aws-amplify/amplify-cli
+src/integ_test_resources/flutter/**               @aws-amplify/amplify-flutter


### PR DESCRIPTION
According to [GitHub docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file), a directory followed by a `/*` only matches one level deep. We need to use `/**` to match nested hierarchies.
