### PR TITLE
chore(flutter): Update GitHub thumbprints

### DIFF
--- a/src/integ_test_resources/flutter/amplify/oidc_provider_stack/cloudformation_template.yaml
+++ b/src/integ_test_resources/flutter/amplify/oidc_provider_stack/cloudformation_template.yaml
@@ -96,6 +96,7 @@ Resources:
       Url: https://token.actions.githubusercontent.com
       ThumbprintList: 
         - 6938fd4d98bab03faadb97b34396831e3780aea1
+        - 1c58a3a8518e8759bf075b76b750d4f2df264fcd
       ClientIdList: 
         - sts.amazonaws.com
 


### PR DESCRIPTION
Updates the thumbprints to include both of GitHub's certificate authorities. See: https://github.blog/changelog/2023-06-27-github-actions-update-on-oidc-integration-with-aws/
