### PR TITLE
ci: use dedicated SES identity for user pool email messaging

### DIFF
--- a/src/integ_test_resources/ios/sdk/integration/cdk/README.md
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/README.md
@@ -1,0 +1,14 @@
+## Parameter
+
+### emailSesIdentityArn
+
+This parameter is the Amazon Resource Name (ARN) of the SES identity, which is utilized to dispatch email messages for the user pools of the `mobileclient` stack.
+
+Usage example:
+
+```
+cdk deploy \
+-c account=$AWS_DEV_ACCOUNT \
+-c region=us-east-1 mobileclient \
+--parameters mobileclient:emailSesIdentityArn='arn:aws:ses:us-east-1:<123123123123>:identity/test@example.com'
+```

--- a/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/mobileclient_stack.py
+++ b/src/integ_test_resources/ios/sdk/integration/cdk/cdk_integration_tests_ios/mobileclient_stack.py
@@ -25,6 +25,12 @@ class MobileClientStack(RegionAwareStack):
 
         super().__init__(scope, id, **kwargs)
 
+        self.user_pool_email_ses_identity_arn = core.CfnParameter(self, "emailSesIdentityArn",
+            type="String",
+            description="The ARN of SES identity used for sending email messages",
+            allowed_pattern="^arn:aws:ses:[a-z0-9\-]+:\d{12}:identity\/.+"
+        )
+
         self._supported_in_region = self.are_services_supported_in_region(
             ["cognito-identity", "cognito-idp"]
         )
@@ -203,6 +209,10 @@ class MobileClientStack(RegionAwareStack):
                 ),
             ],
             lambda_config=lambda_config,
+            email_configuration=aws_cognito.CfnUserPool.EmailConfigurationProperty(
+                source_arn=self.user_pool_email_ses_identity_arn.value_as_string,
+                email_sending_account="DEVELOPER"
+            ),
         )
         return user_pool
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- add parameter `emailSesIdentityArn` as dedicated SES identity for user pool email messaging

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
