### PR TITLE
ci: add cloudfront invalidation permission to github oidc role

### DIFF
--- a/src/release_artifacts_resources/ios/cdk/cdk/distribution_stack.py
+++ b/src/release_artifacts_resources/ios/cdk/cdk/distribution_stack.py
@@ -9,4 +9,4 @@ class DistributionStack(cdk.Stack):
 
         self.s3 = S3Construct(self, "distribution_s3_construct")
         self.cloudfront = CloudFrontConstruct(self, "distribution_cloudfront_construct", self.s3)
-        GithubOIDCRoles(self, "github_oidc_roles", bucket=self.s3.bucket)
+        GithubOIDCRoles(self, "github_oidc_roles", bucket=self.s3.bucket, cloudfront_distribution=self.cloudfront.distribution)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- add `cloudfront:CreateInvalidation ` permission to github OIDC role.
  - `aws-sdk-ios` release will invalidate the cloudfront distribution.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
