### PR TITLE
chore: update commit messages to use release_title instead of product_name

### DIFF
--- a/src/fastlane/release_actions/fastlane/AndroidAppsFastfile
+++ b/src/fastlane/release_actions/fastlane/AndroidAppsFastfile
@@ -123,9 +123,9 @@ platform :android do |options|
         is_draft: true
       }
 
-      pr_title = "release: #{product_name} #{next_version}" unless !pr_title.nil?
-      commit_slug = "release: #{product_name} #{next_version}" unless !commit_slug.nil?
-      pr_body_details << "#{product_name} #{next_version}"
+      pr_title = "release: #{release_title} #{next_version}" unless !pr_title.nil?
+      commit_slug = "release: #{release_title} #{next_version}" unless !commit_slug.nil?
+      pr_body_details << "#{release_title} #{next_version}"
     end
     pr_body = <<~END
       #{pr_body_checklist}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updating commit messages to based of of release_title defined in the configuration instead of the product name.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
