### PR TITLE
chore: update gemfile for dependabot alert fix

### DIFF
--- a/src/fastlane/release_actions/Gemfile
+++ b/src/fastlane/release_actions/Gemfile
@@ -2,5 +2,4 @@ source('https://rubygems.org')
 
 gemspec
 
-plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
-eval_gemfile(plugins_path) if File.exist?(plugins_path)
+eval_gemfile("fastlane/Pluginfile")


### PR DESCRIPTION
*Issue #, if available:*
Dependabot can't read the plugins path as fastlane specified it in the Gemfile.
Using the path directly in `eval_gemfile` should fix the issue, see https://github.com/dependabot/feedback/issues/945#issuecomment-638235801.

*Description of changes:*
Fixing https://github.com/aws-amplify/amplify-ci-support/security/dependabot/51

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
