### PR TITLE
chore: bump aws-cdk-lib

### DIFF
--- a/src/integ_test_resources/flutter/amplify/github-cloudwatch-cdk/package-lock.json
+++ b/src/integ_test_resources/flutter/amplify/github-cloudwatch-cdk/package-lock.json
@@ -8,7 +8,7 @@
       "name": "github-cloudwatch-cdk",
       "version": "0.1.0",
       "dependencies": {
-        "aws-cdk-lib": "^2.184.0",
+        "aws-cdk-lib": "^2.187.0",
         "constructs": "^10.0.0",
         "source-map-support": "^0.5.21"
       },
@@ -50,9 +50,9 @@
       "integrity": "sha512-7bY3J8GCVxLupn/kNmpPc5VJz8grx+4RKfnnJiO1LG+uxkZfANZG3RMHhE+qQxxwkyQ9/MfPtTpf748UhR425A=="
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "40.7.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-40.7.0.tgz",
-      "integrity": "sha512-00wVKn9pOOGXbeNwA4E8FUFt0zIB4PmSO7PvIiDWgpaFX3G/sWyy0A3s6bg/n2Yvkghu8r4a8ckm+mAzkAYmfA==",
+      "version": "41.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-41.2.0.tgz",
+      "integrity": "sha512-JaulVS6z9y5+u4jNmoWbHZRs9uGOnmn/ktXygNWKNu1k6lF3ad4so3s18eRu15XCbUIomxN9WPYT6Ehh7hzONw==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -1185,9 +1185,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.184.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.184.0.tgz",
-      "integrity": "sha512-IC/38376PVCJ9cEsfklH0eBd5uwT7SKZxQJlfAd51TquZ7skpo7dt9oetrkUk4H+tsg4VcTF5B0ZbVZdDDP2yg==",
+      "version": "2.187.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.187.0.tgz",
+      "integrity": "sha512-OrAWin+LD5sZhRF5cWuEYEkmC/sxxlgcAasCpfzeRsj6yDImwmeQsaKhM7xqzZQBInog6ZbN6oFZYiWEGJMSIA==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -1203,9 +1203,9 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.227",
+        "@aws-cdk/asset-awscli-v1": "^2.2.229",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
-        "@aws-cdk/cloud-assembly-schema": "^40.7.0",
+        "@aws-cdk/cloud-assembly-schema": "^41.0.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.3.0",
@@ -3621,7 +3621,6 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }

--- a/src/integ_test_resources/flutter/amplify/github-cloudwatch-cdk/package.json
+++ b/src/integ_test_resources/flutter/amplify/github-cloudwatch-cdk/package.json
@@ -21,7 +21,7 @@
     "typescript": "~5.0.4"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.184.0",
+    "aws-cdk-lib": "^2.187.0",
     "constructs": "^10.0.0",
     "source-map-support": "^0.5.21"
   },

--- a/src/monitoring_resources/cli_binary_integrity/package-lock.json
+++ b/src/monitoring_resources/cli_binary_integrity/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "aws-cdk": "^2.22.0",
-        "aws-cdk-lib": "^2.184.0",
+        "aws-cdk-lib": "^2.187.0",
         "constructs": "^10.0.130",
         "prettier": "^2.6.2",
         "typescript": "^4.6.4"
@@ -22,9 +22,9 @@
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.228",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.228.tgz",
-      "integrity": "sha512-ToZPI+dEz2BKj//kD2V8oXAvpeBFec5w6tXxIQh/U2iiMLcaUVZw4sxR820jF2GDArZY2D/alVkcSkId0J6rtA==",
+      "version": "2.2.230",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.230.tgz",
+      "integrity": "sha512-kUnhKIYu42hqBa6a8x2/7o29ObpJgjYGQy28lZDq9awXyvpR62I2bRxrNKNR3uFUQz3ySuT9JXhGHhuZPdbnFw==",
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
@@ -34,9 +34,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "40.7.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-40.7.0.tgz",
-      "integrity": "sha512-00wVKn9pOOGXbeNwA4E8FUFt0zIB4PmSO7PvIiDWgpaFX3G/sWyy0A3s6bg/n2Yvkghu8r4a8ckm+mAzkAYmfA==",
+      "version": "41.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-41.2.0.tgz",
+      "integrity": "sha512-JaulVS6z9y5+u4jNmoWbHZRs9uGOnmn/ktXygNWKNu1k6lF3ad4so3s18eRu15XCbUIomxN9WPYT6Ehh7hzONw==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -90,9 +90,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.184.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.184.0.tgz",
-      "integrity": "sha512-IC/38376PVCJ9cEsfklH0eBd5uwT7SKZxQJlfAd51TquZ7skpo7dt9oetrkUk4H+tsg4VcTF5B0ZbVZdDDP2yg==",
+      "version": "2.187.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.187.0.tgz",
+      "integrity": "sha512-OrAWin+LD5sZhRF5cWuEYEkmC/sxxlgcAasCpfzeRsj6yDImwmeQsaKhM7xqzZQBInog6ZbN6oFZYiWEGJMSIA==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -108,9 +108,9 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.227",
+        "@aws-cdk/asset-awscli-v1": "^2.2.229",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
-        "@aws-cdk/cloud-assembly-schema": "^40.7.0",
+        "@aws-cdk/cloud-assembly-schema": "^41.0.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.3.0",

--- a/src/monitoring_resources/cli_binary_integrity/package.json
+++ b/src/monitoring_resources/cli_binary_integrity/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "aws-cdk": "^2.22.0",
-    "aws-cdk-lib": "^2.184.0",
+    "aws-cdk-lib": "^2.187.0",
     "constructs": "^10.0.130",
     "prettier": "^2.6.2",
     "typescript": "^4.6.4"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Bump `aws-cdk-lib` to patched version of `2.187.0` to address:
https://github.com/aws-amplify/amplify-ci-support/security/dependabot/72
https://github.com/aws-amplify/amplify-ci-support/security/dependabot/71
